### PR TITLE
fix: obo 노드 컴포넌트의 data 타입 캐스팅 오류 수정

### DIFF
--- a/components/obo/nodes/AnnotationLabelNode.tsx
+++ b/components/obo/nodes/AnnotationLabelNode.tsx
@@ -9,7 +9,7 @@ interface AnnotationLabelNodeData {
 }
 
 export function AnnotationLabelNode({ data, selected }: NodeProps) {
-  const d = data as AnnotationLabelNodeData;
+  const d = data as unknown as AnnotationLabelNodeData;
   const color = d.color ?? '#e24b4a';
   const borderStyle = d.style ?? 'dashed';
   const border = borderStyle === 'plain' ? 'none' : `1.5px ${borderStyle} ${color}`;

--- a/components/obo/nodes/CircleNode.tsx
+++ b/components/obo/nodes/CircleNode.tsx
@@ -9,7 +9,7 @@ interface CircleNodeData {
 }
 
 export function CircleNode({ data, selected }: NodeProps) {
-  const d = data as CircleNodeData;
+  const d = data as unknown as CircleNodeData;
   const color = d.color ?? '#6366f1';
   const hs = { width: 8, height: 8, background: color, border: 'none' };
   return (

--- a/components/obo/nodes/CounterBadgeNode.tsx
+++ b/components/obo/nodes/CounterBadgeNode.tsx
@@ -10,7 +10,7 @@ interface CounterBadgeNodeData {
 }
 
 export function CounterBadgeNode({ data, selected }: NodeProps) {
-  const d = data as CounterBadgeNodeData;
+  const d = data as unknown as CounterBadgeNodeData;
   const color = d.color ?? '#b45309';
   return (
     <div style={{

--- a/components/obo/nodes/FaultMarkerNode.tsx
+++ b/components/obo/nodes/FaultMarkerNode.tsx
@@ -10,7 +10,7 @@ interface FaultMarkerNodeData {
 }
 
 export function FaultMarkerNode({ data, selected }: NodeProps) {
-  const d = data as FaultMarkerNodeData;
+  const d = data as unknown as FaultMarkerNodeData;
   const markers = d.markers ?? [];
   const faultColor = d.faultColor ?? '#E24B4A';
   const hitColor = d.hitColor ?? '#1D9E75';

--- a/components/obo/nodes/GanttBlockNode.tsx
+++ b/components/obo/nodes/GanttBlockNode.tsx
@@ -11,7 +11,7 @@ interface GanttBlockNodeData {
 }
 
 export function GanttBlockNode({ data, selected }: NodeProps) {
-  const d = data as GanttBlockNodeData;
+  const d = data as unknown as GanttBlockNodeData;
   const scale = d.scaleUnit ?? 20;
   const color = d.color ?? '#1D9E75';
   const width = Math.max((d.duration ?? 3) * scale, 40);

--- a/components/obo/nodes/LineChartNode.tsx
+++ b/components/obo/nodes/LineChartNode.tsx
@@ -12,7 +12,7 @@ interface LineChartNodeData {
 }
 
 export function LineChartNode({ data, selected }: NodeProps) {
-  const d = data as LineChartNodeData;
+  const d = data as unknown as LineChartNodeData;
   const W = d.width ?? 160;
   const H = d.height ?? 100;
   const pts = d.points ?? [];

--- a/components/obo/nodes/MemoryFrameNode.tsx
+++ b/components/obo/nodes/MemoryFrameNode.tsx
@@ -10,7 +10,7 @@ interface MemoryFrameNodeData {
 }
 
 export function MemoryFrameNode({ data, selected }: NodeProps) {
-  const d = data as MemoryFrameNodeData;
+  const d = data as unknown as MemoryFrameNodeData;
   const count = d.frameCount ?? 4;
   const pages = d.pages ?? Array(count).fill(null);
   const color = d.color ?? '#6366f1';

--- a/components/obo/nodes/ProcessBoxNode.tsx
+++ b/components/obo/nodes/ProcessBoxNode.tsx
@@ -14,7 +14,7 @@ interface ProcessBoxNodeData {
 }
 
 export function ProcessBoxNode({ data, selected }: NodeProps) {
-  const d = data as ProcessBoxNodeData;
+  const d = data as unknown as ProcessBoxNodeData;
   const sections = d.sections ?? [
     { name: 'Code' }, { name: 'Data' }, { name: 'Heap' }, { name: 'Stack' },
   ];

--- a/components/obo/nodes/QueueStripNode.tsx
+++ b/components/obo/nodes/QueueStripNode.tsx
@@ -10,7 +10,7 @@ interface QueueStripNodeData {
 }
 
 export function QueueStripNode({ data, selected }: NodeProps) {
-  const d = data as QueueStripNodeData;
+  const d = data as unknown as QueueStripNodeData;
   const items = d.items ?? [];
   const color = d.color ?? '#534AB7';
   const dir = d.direction ?? 'ltr';

--- a/components/obo/nodes/RectNode.tsx
+++ b/components/obo/nodes/RectNode.tsx
@@ -9,7 +9,7 @@ interface RectNodeData {
 }
 
 export function RectNode({ data, selected }: NodeProps) {
-  const d = data as RectNodeData;
+  const d = data as unknown as RectNodeData;
   const color = d.color ?? '#64748b';
   const borderRadius = d.shape === 'pill' ? 9999 : 8;
   const hs = { width: 7, height: 7, background: color, border: 'none' };

--- a/components/obo/nodes/ResourceNode.tsx
+++ b/components/obo/nodes/ResourceNode.tsx
@@ -9,7 +9,7 @@ interface ResourceNodeData {
 }
 
 export function ResourceNode({ data, selected }: NodeProps) {
-  const d = data as ResourceNodeData;
+  const d = data as unknown as ResourceNodeData;
   const count = d.instanceCount ?? 1;
   const color = d.color ?? '#1e293b';
   const hs = { width: 7, height: 7, background: color, border: 'none' };

--- a/components/obo/nodes/TableGridNode.tsx
+++ b/components/obo/nodes/TableGridNode.tsx
@@ -17,7 +17,7 @@ interface TableGridNodeData {
 }
 
 export function TableGridNode({ data, selected }: NodeProps) {
-  const d = data as TableGridNodeData;
+  const d = data as unknown as TableGridNodeData;
   const color = d.color ?? '#6366f1';
   const rows = d.rows ?? [];
 

--- a/components/obo/nodes/TimelineStepNode.tsx
+++ b/components/obo/nodes/TimelineStepNode.tsx
@@ -15,7 +15,7 @@ interface TimelineStepNodeData {
 }
 
 export function TimelineStepNode({ data, selected }: NodeProps) {
-  const d = data as TimelineStepNodeData;
+  const d = data as unknown as TimelineStepNodeData;
   const steps = d.steps ?? [{ label: 'Step 1' }];
   const mainColor = '#334155';
   const hs = { background: mainColor, border: 'none' };


### PR DESCRIPTION
NodeProps의 data가 Record<string, unknown>이라 각 NodeData 타입으로 직접 캐스팅이 불가능해 빌드가 실패하던 문제를 unknown 경유 캐스팅으로 해결