### PR TITLE
feat: OBO 코딩 diff 모드 추가 (자유 텍스트 트레이스 기반 자동 채점)

### DIFF
--- a/app/challenges/create/page.tsx
+++ b/app/challenges/create/page.tsx
@@ -1228,6 +1228,10 @@ function ProblemCreateContent() {
                   choices={problemType === 'objective'
                     ? choices.map(c => ({ id: `choice_${c.index}`, text: c.content }))
                     : undefined}
+                  allowCodingDiff={problemType === 'coding'}
+                  testcaseOutputs={problemType === 'coding'
+                    ? testcases.map(tc => ({ index: tc.index, output: tc.output }))
+                    : undefined}
                 />
               </div>
             </div>

--- a/app/test/problem/coding-diff/page.tsx
+++ b/app/test/problem/coding-diff/page.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+import type { Node, Edge } from '@xyflow/react';
+import { OBO_TEMPLATES } from '@/components/obo/templates';
+import type { OboCodingSchema } from '@/components/obo/types';
+import { parseTraceText } from '@/components/obo/lib/traceParser';
+import { CodingDiffPlayer } from '@/components/obo/CodingDiffPlayer';
+import { Button } from '@/components/ui/button';
+
+function toBlobNodes(nodes: Node[]) {
+  return nodes.map(({ id, type, position, data }) => ({ id, type, position, data: data as Record<string, unknown> }));
+}
+function toBlobEdges(edges: Edge[]) {
+  return edges.map(({ id, source, target, sourceHandle, targetHandle, data }) => ({
+    id, source, target, sourceHandle: sourceHandle ?? null, targetHandle: targetHandle ?? null,
+    data: (data ?? {}) as Record<string, unknown>,
+  }));
+}
+
+// ── 값 기반: S1 페이지 교체(FIFO). slot-grid 노드 id 'frames'의 slots 값이 스텝마다 바뀐다 ──
+const S1 = OBO_TEMPLATES.find(t => t.id === 'S1')!;
+const fifoNodes = toBlobNodes(S1.defaultNodes);
+const fifoEdges = toBlobEdges(S1.defaultEdges);
+
+const FIFO_REFERENCE_TEXT = [
+  'frames [7,null,null]',
+  'frames [7,0,null]',
+  'frames [7,0,1]',
+  'frames [2,0,1]',
+  'frames [2,0,1]',
+  'frames [2,3,1]',
+  'frames [2,3,0]',
+  'frames [4,3,0]',
+].join('\n');
+
+const fifoSchema: OboCodingSchema = {
+  nodes: fifoNodes,
+  edges: fifoEdges,
+  referenceTrace: parseTraceText(FIFO_REFERENCE_TEXT, S1.defaultNodes),
+};
+
+const fifoScenarios = {
+  all_correct: { label: '전부 정답', text: FIFO_REFERENCE_TEXT },
+  middle_wrong: {
+    label: '중간 오답 (스텝5)',
+    text: FIFO_REFERENCE_TEXT.split('\n').map((l, i) => (i === 4 ? 'frames [2,9,1]' : l)).join('\n'),
+  },
+  first_wrong: {
+    label: '첫 스텝부터 오답',
+    text: FIFO_REFERENCE_TEXT.split('\n').map((l, i) => (i === 0 ? 'frames [1,null,null]' : l)).join('\n'),
+  },
+};
+
+// ── 강조 기반: ST2 프로세스 상태 전이. New → Ready → Running → Terminated ──
+const ST2 = OBO_TEMPLATES.find(t => t.id === 'ST2')!;
+const st2Nodes = toBlobNodes(ST2.defaultNodes);
+const st2Edges = toBlobEdges(ST2.defaultEdges);
+
+const ST2_REFERENCE_TEXT = ['new ready', 'ready running', 'running terminated'].join('\n');
+
+const st2Schema: OboCodingSchema = {
+  nodes: st2Nodes,
+  edges: st2Edges,
+  referenceTrace: parseTraceText(ST2_REFERENCE_TEXT, ST2.defaultNodes),
+};
+
+const st2Scenarios = {
+  all_correct: { label: '전부 정답', text: ST2_REFERENCE_TEXT },
+  middle_wrong: {
+    label: '중간 오답 (2번째 줄, running 대신 waiting)',
+    text: ['new ready', 'ready waiting', 'running terminated'].join('\n'),
+  },
+  first_wrong: {
+    label: '첫 줄부터 오답 (ready 대신 waiting)',
+    text: ['new waiting', 'ready running', 'running terminated'].join('\n'),
+  },
+};
+
+type DemoKey = 'fifo' | 'st2';
+type ScenarioKey = keyof typeof fifoScenarios;
+
+export default function CodingDiffTestPage() {
+  const [demo, setDemo] = useState<DemoKey>('fifo');
+  const [scenario, setScenario] = useState<ScenarioKey>('all_correct');
+  const [attempt, setAttempt] = useState(0);
+
+  const schema = demo === 'fifo' ? fifoSchema : st2Schema;
+  const scenarios = demo === 'fifo' ? fifoScenarios : st2Scenarios;
+  const rawNodes = demo === 'fifo' ? S1.defaultNodes : ST2.defaultNodes;
+  const submittedTrace = parseTraceText(scenarios[scenario].text, rawNodes);
+
+  return (
+    <div className="h-screen flex flex-col bg-white overflow-hidden">
+      <header className="border-b px-6 py-4 space-y-3 shrink-0">
+        <div className="flex items-center gap-3">
+          <span className="font-bold text-slate-900">coding_diff 검증 페이지 (자유텍스트 트레이스)</span>
+          <div className="flex items-center bg-slate-100 rounded-lg p-0.5">
+            <button
+              onClick={() => { setDemo('fifo'); setScenario('all_correct'); setAttempt(a => a + 1); }}
+              className={`px-2.5 py-1 text-[11px] font-bold rounded-md transition-all ${demo === 'fifo' ? 'bg-white shadow-sm text-slate-900' : 'text-slate-500'}`}
+            >
+              값 기반 (FIFO)
+            </button>
+            <button
+              onClick={() => { setDemo('st2'); setScenario('all_correct'); setAttempt(a => a + 1); }}
+              className={`px-2.5 py-1 text-[11px] font-bold rounded-md transition-all ${demo === 'st2' ? 'bg-white shadow-sm text-slate-900' : 'text-slate-500'}`}
+            >
+              강조 기반 (상태 전이)
+            </button>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          {(Object.keys(scenarios) as ScenarioKey[]).map(key => (
+            <Button
+              key={key}
+              size="sm"
+              variant={scenario === key ? 'default' : 'outline'}
+              onClick={() => { setScenario(key); setAttempt(a => a + 1); }}
+            >
+              {scenarios[key].label}
+            </Button>
+          ))}
+          <Button size="sm" variant="ghost" onClick={() => setAttempt(a => a + 1)}>
+            재도전 (같은 시나리오로 재마운트)
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex-1 min-h-0 p-4">
+        <CodingDiffPlayer
+          schema={schema}
+          submittedTrace={submittedTrace}
+          resubmitKey={`${demo}-${scenario}-${attempt}`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/obo/CodingDiffPlayer.tsx
+++ b/components/obo/CodingDiffPlayer.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { OboCodingSchema, OboTraceStep } from './types';
+import { buildCodingDiffPlan } from './lib/codingDiff';
+import { OboPlayer } from './OboPlayer';
+
+interface CodingDiffPlayerProps {
+  schema: OboCodingSchema;
+  submittedTrace: OboTraceStep[];
+  resubmitKey: string | number;
+}
+
+export function CodingDiffPlayer({ schema, submittedTrace, resubmitKey }: CodingDiffPlayerProps) {
+  const plan = useMemo(
+    () => buildCodingDiffPlan(schema, submittedTrace),
+    [schema, submittedTrace]
+  );
+
+  return (
+    <OboPlayer
+      key={resubmitKey}
+      blob={plan.blob}
+      maxFrameIndex={plan.stopAtFrameIndex}
+      checkpointStatusByFrame={plan.statusByFrameId}
+      autoPlay
+    />
+  );
+}

--- a/components/obo/FrameContext.ts
+++ b/components/obo/FrameContext.ts
@@ -5,6 +5,7 @@ import type { Frame } from './types';
 
 interface FrameCtx {
   previewFrame: Frame | null;
+  checkpointStatus?: Record<string, 'correct' | 'incorrect'>;
 }
 
 export const FrameContext = createContext<FrameCtx>({ previewFrame: null });

--- a/components/obo/OBOEditorCanvas.tsx
+++ b/components/obo/OBOEditorCanvas.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -25,6 +25,8 @@ import { FrameContext } from './FrameContext';
 import { nodeTypes } from './nodes';
 import { DEFAULT_NODE_DATA } from './nodes/defaultNodeData';
 import { OboEdge } from './edges/OboEdge';
+import { nextNodeId, nextEdgeId } from './lib/id';
+import { applyFrame } from './lib/applyFrame';
 
 const edgeTypes = { 'obo-edge': OboEdge } as const;
 
@@ -40,6 +42,7 @@ interface OBOEditorCanvasProps {
   onSelect: (id: string | null, kind: 'node' | 'edge' | null) => void;
   // 프레임 탭
   activeTab: 'property' | 'frame';
+  frames: Frame[];
   previewFrame: Frame | null;
   onFrameNodeClick: (nodeId: string) => void;
   onFrameEdgeClick: (edgeId: string) => void;
@@ -48,23 +51,29 @@ interface OBOEditorCanvasProps {
 function CanvasInner({
   nodes, edges, onNodesChange, onEdgesChange,
   setNodes, setEdges, activeEdgeType, onSelect,
-  activeTab, previewFrame, onFrameNodeClick, onFrameEdgeClick,
+  activeTab, frames, previewFrame, onFrameNodeClick, onFrameEdgeClick,
 }: OBOEditorCanvasProps) {
   const { screenToFlowPosition } = useReactFlow();
+
+  const previewIndex = previewFrame ? frames.findIndex(f => f.id === previewFrame.id) : -1;
+  const displayNodes = useMemo(
+    () => (previewIndex >= 0 ? applyFrame(nodes, frames, previewIndex) : nodes),
+    [nodes, frames, previewIndex]
+  );
 
   const onConnect = useCallback((params: Connection) => {
     const isBidi  = activeEdgeType === 'bidirectional';
     const isAlloc = activeEdgeType === 'allocation';
     setEdges(eds => addEdge({
       ...params,
-      id: `e_${Date.now()}`,
+      id: nextEdgeId(eds),
       type: 'obo-edge',
       data: {
         label: '',
         direction: isBidi  ? 'both'       : 'forward',
         style:     isAlloc ? 'dashed'     : 'solid',
         role:      isAlloc ? 'allocation' : 'transition',
-        highlight: false,
+        emphasize: false,
       },
     } as Edge, eds));
   }, [activeEdgeType, setEdges]);
@@ -75,7 +84,7 @@ function CanvasInner({
     if (!type) return;
     const position = screenToFlowPosition({ x: e.clientX, y: e.clientY });
     setNodes(nds => [...nds, {
-      id: `${type}-${Date.now()}`,
+      id: nextNodeId(nds),
       type,
       position,
       data: { ...(DEFAULT_NODE_DATA[type] ?? { label: type }) },
@@ -114,7 +123,7 @@ function CanvasInner({
           </div>
         )}
         <ReactFlow
-          nodes={nodes}
+          nodes={displayNodes}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}

--- a/components/obo/OBOEditorPage.tsx
+++ b/components/obo/OBOEditorPage.tsx
@@ -45,7 +45,7 @@ export function OBOEditorPage() {
     setSelectedId(null);
     setSelectedKind(null);
     setJsonVisible(false);
-    setFrames([]);
+    setFrames(template.defaultFrames ?? []);
     setSelectedFrameId(null);
   }, [nodes.length, edges.length, setNodes, setEdges]);
 
@@ -69,7 +69,17 @@ export function OBOEditorPage() {
     if (selectedKind === 'node') {
       setNodes(nds => nds.filter(n => n.id !== selectedId));
       setEdges(eds => eds.filter(e => e.source !== selectedId && e.target !== selectedId));
-      setFrames(fs => fs.map(f => ({ ...f, highlightNodes: f.highlightNodes.filter(id => id !== selectedId) })));
+      setFrames(fs => fs.map(f => {
+        if (!f.nodeDataOverrides?.[selectedId]) {
+          return { ...f, highlightNodes: f.highlightNodes.filter(id => id !== selectedId) };
+        }
+        const { [selectedId]: _removed, ...restOverrides } = f.nodeDataOverrides;
+        return {
+          ...f,
+          highlightNodes: f.highlightNodes.filter(id => id !== selectedId),
+          nodeDataOverrides: restOverrides,
+        };
+      }));
     } else {
       setEdges(eds => eds.filter(e => e.id !== selectedId));
       setFrames(fs => fs.map(f => ({ ...f, highlightEdges: f.highlightEdges.filter(id => id !== selectedId) })));
@@ -122,6 +132,47 @@ export function OBOEditorPage() {
     setFrames(fs => fs.map(f => f.id !== frameId ? f : {
       ...f, highlightEdges: f.highlightEdges.filter(id => id !== edgeId),
     }));
+  }, []);
+
+  const addNodeOverride = useCallback((frameId: string, nodeId: string) => {
+    setFrames(fs => fs.map(f => f.id !== frameId ? f : {
+      ...f,
+      nodeDataOverrides: { ...(f.nodeDataOverrides ?? {}), [nodeId]: f.nodeDataOverrides?.[nodeId] ?? {} },
+    }));
+  }, []);
+
+  const removeNodeOverride = useCallback((frameId: string, nodeId: string) => {
+    setFrames(fs => fs.map(f => {
+      if (f.id !== frameId || !f.nodeDataOverrides) return f;
+      const { [nodeId]: _removed, ...rest } = f.nodeDataOverrides;
+      return { ...f, nodeDataOverrides: rest };
+    }));
+  }, []);
+
+  const setOverrideField = useCallback((frameId: string, nodeId: string, field: string, value: unknown) => {
+    setFrames(fs => fs.map(f => f.id !== frameId ? f : {
+      ...f,
+      nodeDataOverrides: {
+        ...(f.nodeDataOverrides ?? {}),
+        [nodeId]: { ...(f.nodeDataOverrides?.[nodeId] ?? {}), [field]: value },
+      },
+    }));
+  }, []);
+
+  const clearOverrideField = useCallback((frameId: string, nodeId: string, field: string) => {
+    setFrames(fs => fs.map(f => {
+      const existing = f.nodeDataOverrides?.[nodeId];
+      if (f.id !== frameId || !existing) return f;
+      const { [field]: _removed, ...restFields } = existing;
+      return {
+        ...f,
+        nodeDataOverrides: { ...f.nodeDataOverrides, [nodeId]: restFields },
+      };
+    }));
+  }, []);
+
+  const updateFrameCursorTime = useCallback((frameId: string, cursorTime: number | undefined) => {
+    setFrames(fs => fs.map(f => f.id !== frameId ? f : { ...f, cursorTime }));
   }, []);
 
   // 캔버스 클릭 → 프레임 탭에서 하이라이트 토글
@@ -207,6 +258,7 @@ export function OBOEditorPage() {
           activeEdgeType={activeEdgeType}
           onSelect={handleSelect}
           activeTab={activeTab}
+          frames={frames}
           previewFrame={previewFrame}
           onFrameNodeClick={handleFrameNodeClick}
           onFrameEdgeClick={handleFrameEdgeClick}
@@ -228,6 +280,7 @@ export function OBOEditorPage() {
           currentEdges={edges}
           onJsonClose={() => setJsonVisible(false)}
           onDelete={deleteSelected}
+          oboMode="single"
           frames={frames}
           selectedFrameId={selectedFrameId}
           onSelectFrame={setSelectedFrameId}
@@ -236,6 +289,13 @@ export function OBOEditorPage() {
           onUpdateFrameLabel={updateFrameLabel}
           onRemoveHighlightNode={removeHighlightNode}
           onRemoveHighlightEdge={removeHighlightEdge}
+          onAddNodeOverride={addNodeOverride}
+          onRemoveNodeOverride={removeNodeOverride}
+          onSetOverrideField={setOverrideField}
+          onClearOverrideField={clearOverrideField}
+          onUpdateFrameCursorTime={updateFrameCursorTime}
+          traceText=""
+          onTraceTextChange={() => {}}
         />
       </div>
 

--- a/components/obo/OboEditorSection.tsx
+++ b/components/obo/OboEditorSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNodesState, useEdgesState } from '@xyflow/react';
 import type { Node, Edge } from '@xyflow/react';
 import { CheckCircle2, X } from 'lucide-react';
@@ -11,6 +11,9 @@ import { OBOEditorCanvas } from './OBOEditorCanvas';
 import { PropertyPanel } from './panel/PropertyPanel';
 import { OboPlayer } from './OboPlayer';
 import { Button } from '@/components/ui/button';
+import { nextFrameId } from './lib/id';
+import { generateFramesFromTrace } from './lib/trace';
+import { parseTraceText, stringifyTrace } from './lib/traceParser';
 
 export interface OboChoice { id: string; text: string; }
 
@@ -18,6 +21,8 @@ interface Props {
   value: ProblemOboData | null;
   onChange: (data: ProblemOboData) => void;
   choices?: OboChoice[];
+  allowCodingDiff?: boolean;
+  testcaseOutputs?: { index: number; output: string }[];
 }
 
 const EMPTY_BLOB: OboBlob = { nodes: [], edges: [], frames: [] };
@@ -38,13 +43,17 @@ function serialize(nodes: Node[], edges: Edge[], frames: Frame[]): OboBlob {
 }
 
 export const OboEditorSection = React.memo(function OboEditorSection({
-  value, onChange, choices = [],
+  value, onChange, choices = [], allowCodingDiff = false, testcaseOutputs,
 }: Props) {
-  const initMode: OboMode = value?.mode ?? 'single';
+  const initMode: OboMode = value?.mode ?? (allowCodingDiff ? 'coding_diff' : 'single');
   const initChoiceId = choices[0]?.id ?? null;
 
   const getBlob = (m: OboMode, id: string | null): OboBlob => {
     if (m === 'single') return value?.single ?? EMPTY_BLOB;
+    if (m === 'coding_diff') {
+      const schema = value?.codingDiff;
+      return schema ? { nodes: schema.nodes, edges: schema.edges, frames: [] } : EMPTY_BLOB;
+    }
     return id ? (value?.perChoice?.[id] ?? EMPTY_BLOB) : EMPTY_BLOB;
   };
 
@@ -52,12 +61,18 @@ export const OboEditorSection = React.memo(function OboEditorSection({
   const [mode, setMode] = useState<OboMode>(initMode);
   const [activeChoiceId, setActiveChoiceId] = useState<string | null>(initChoiceId);
   const perChoiceMapRef = useRef<Record<string, OboBlob>>(value?.perChoice ?? {});
+  // coding_diff 전용: frames를 손으로 안 만들고, 자유텍스트 트레이스로부터 자동 생성.
+  // traceText가 유일한 source of truth — referenceTrace는 여기서 파생된다(아래 useMemo).
+  const [traceText, setTraceText] = useState<string>(() =>
+    value?.codingDiff ? stringifyTrace(value.codingDiff.referenceTrace, value.codingDiff.nodes as Node[]) : ''
+  );
 
   // ── React Flow 상태 ───────────────────────────────────
   const init = getBlob(initMode, initChoiceId);
   const [nodes, setNodes, onNodesChange] = useNodesState<Node>(init.nodes as Node[]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(init.edges as Edge[]);
   const [frames, setFrames] = useState<Frame[]>(init.frames);
+  const referenceTrace = useMemo(() => parseTraceText(traceText, nodes), [traceText, nodes]);
 
   // ── 에디터 UI 상태 ────────────────────────────────────
   const [selectedTemplate, setSelectedTemplate] = useState<OBOTemplate | null>(null);
@@ -75,27 +90,34 @@ export const OboEditorSection = React.memo(function OboEditorSection({
 
   // ── 변경 전파 ─────────────────────────────────────────
   useEffect(() => {
-    const blob = serialize(nodes, edges, frames);
     if (mode === 'single') {
-      onChangeRef.current({ mode: 'single', single: blob });
+      onChangeRef.current({ mode: 'single', single: serialize(nodes, edges, frames) });
+    } else if (mode === 'coding_diff') {
+      const blob = serialize(nodes, edges, []);
+      onChangeRef.current({
+        mode: 'coding_diff',
+        codingDiff: { nodes: blob.nodes, edges: blob.edges, referenceTrace },
+      });
     } else if (activeChoiceId) {
+      const blob = serialize(nodes, edges, frames);
       perChoiceMapRef.current = { ...perChoiceMapRef.current, [activeChoiceId]: blob };
       onChangeRef.current({ mode: 'per_choice', perChoice: { ...perChoiceMapRef.current } });
     }
-  }, [nodes, edges, frames, mode, activeChoiceId]);
+  }, [nodes, edges, frames, mode, activeChoiceId, referenceTrace]);
 
   // ── 모드 전환 ─────────────────────────────────────────
   const handleModeChange = useCallback((newMode: OboMode) => {
     if (newMode === mode) return;
-    const hasContent = mode === 'single'
-      ? nodes.length > 0
-      : Object.values(perChoiceMapRef.current).some(b => b.nodes.length > 0);
+    const hasContent = mode === 'per_choice'
+      ? Object.values(perChoiceMapRef.current).some(b => b.nodes.length > 0)
+      : nodes.length > 0;
     if (hasContent && !window.confirm('모드를 변경하면 현재 작성된 OBO 내용이 초기화됩니다. 계속할까요?')) return;
 
     perChoiceMapRef.current = {};
     setNodes([]);
     setEdges([]);
     setFrames([]);
+    setTraceText('');
     setSelectedId(null);
     setSelectedKind(null);
     setSelectedFrameId(null);
@@ -126,7 +148,7 @@ export const OboEditorSection = React.memo(function OboEditorSection({
     setSelectedId(null);
     setSelectedKind(null);
     setJsonVisible(false);
-    setFrames([]);
+    setFrames(template.defaultFrames ?? []);
     setSelectedFrameId(null);
   }, [nodes.length, edges.length, setNodes, setEdges]);
 
@@ -150,7 +172,17 @@ export const OboEditorSection = React.memo(function OboEditorSection({
     if (selectedKind === 'node') {
       setNodes(nds => nds.filter(n => n.id !== selectedId));
       setEdges(eds => eds.filter(e => e.source !== selectedId && e.target !== selectedId));
-      setFrames(fs => fs.map(f => ({ ...f, highlightNodes: f.highlightNodes.filter(id => id !== selectedId) })));
+      setFrames(fs => fs.map(f => {
+        if (!f.nodeDataOverrides?.[selectedId]) {
+          return { ...f, highlightNodes: f.highlightNodes.filter(id => id !== selectedId) };
+        }
+        const { [selectedId]: _removed, ...restOverrides } = f.nodeDataOverrides;
+        return {
+          ...f,
+          highlightNodes: f.highlightNodes.filter(id => id !== selectedId),
+          nodeDataOverrides: restOverrides,
+        };
+      }));
     } else {
       setEdges(eds => eds.filter(e => e.id !== selectedId));
       setFrames(fs => fs.map(f => ({ ...f, highlightEdges: f.highlightEdges.filter(id => id !== selectedId) })));
@@ -161,10 +193,10 @@ export const OboEditorSection = React.memo(function OboEditorSection({
 
   // ── 프레임 탭 ─────────────────────────────────────────
   const addFrame = useCallback(() => {
-    const id = `f_${Date.now()}`;
+    const id = nextFrameId(frames);
     setFrames(fs => [...fs, { id, label: '', highlightNodes: [], highlightEdges: [] }]);
     setSelectedFrameId(id);
-  }, []);
+  }, [frames]);
 
   const removeFrame = useCallback((id: string) => {
     setFrames(fs => fs.filter(f => f.id !== id));
@@ -205,6 +237,47 @@ export const OboEditorSection = React.memo(function OboEditorSection({
     }));
   }, []);
 
+  const addNodeOverride = useCallback((frameId: string, nodeId: string) => {
+    setFrames(fs => fs.map(f => f.id !== frameId ? f : {
+      ...f,
+      nodeDataOverrides: { ...(f.nodeDataOverrides ?? {}), [nodeId]: f.nodeDataOverrides?.[nodeId] ?? {} },
+    }));
+  }, []);
+
+  const removeNodeOverride = useCallback((frameId: string, nodeId: string) => {
+    setFrames(fs => fs.map(f => {
+      if (f.id !== frameId || !f.nodeDataOverrides) return f;
+      const { [nodeId]: _removed, ...rest } = f.nodeDataOverrides;
+      return { ...f, nodeDataOverrides: rest };
+    }));
+  }, []);
+
+  const setOverrideField = useCallback((frameId: string, nodeId: string, field: string, value: unknown) => {
+    setFrames(fs => fs.map(f => f.id !== frameId ? f : {
+      ...f,
+      nodeDataOverrides: {
+        ...(f.nodeDataOverrides ?? {}),
+        [nodeId]: { ...(f.nodeDataOverrides?.[nodeId] ?? {}), [field]: value },
+      },
+    }));
+  }, []);
+
+  const clearOverrideField = useCallback((frameId: string, nodeId: string, field: string) => {
+    setFrames(fs => fs.map(f => {
+      const existing = f.nodeDataOverrides?.[nodeId];
+      if (f.id !== frameId || !existing) return f;
+      const { [field]: _removed, ...restFields } = existing;
+      return {
+        ...f,
+        nodeDataOverrides: { ...f.nodeDataOverrides, [nodeId]: restFields },
+      };
+    }));
+  }, []);
+
+  const updateFrameCursorTime = useCallback((frameId: string, cursorTime: number | undefined) => {
+    setFrames(fs => fs.map(f => f.id !== frameId ? f : { ...f, cursorTime }));
+  }, []);
+
   const handleFrameNodeClick = useCallback((nodeId: string) => {
     if (selectedFrameId) toggleHighlightNode(selectedFrameId, nodeId);
   }, [selectedFrameId, toggleHighlightNode]);
@@ -219,9 +292,11 @@ export const OboEditorSection = React.memo(function OboEditorSection({
 
   const panelMode = jsonVisible ? 'json' : (selectedId ? 'property' : 'palette');
 
-  const previewBlob: OboBlob = mode === 'single'
-    ? serialize(nodes, edges, frames)
-    : (activeChoiceId ? (perChoiceMapRef.current[activeChoiceId] ?? EMPTY_BLOB) : EMPTY_BLOB);
+  const previewBlob: OboBlob = mode === 'per_choice'
+    ? (activeChoiceId ? (perChoiceMapRef.current[activeChoiceId] ?? EMPTY_BLOB) : EMPTY_BLOB)
+    : mode === 'coding_diff'
+      ? (() => { const b = serialize(nodes, edges, []); return { ...b, frames: generateFramesFromTrace(referenceTrace, b.edges) }; })()
+      : serialize(nodes, edges, frames);
 
   return (
     <div className="h-full flex flex-col">
@@ -246,6 +321,16 @@ export const OboEditorSection = React.memo(function OboEditorSection({
             >
               보기별
             </button>
+            {allowCodingDiff && (
+              <button
+                onClick={() => handleModeChange('coding_diff')}
+                className={`px-3 py-1 text-[11px] font-bold rounded-md transition-all ${
+                  mode === 'coding_diff' ? 'bg-white shadow-sm text-slate-900' : 'text-slate-500 hover:text-slate-700'
+                }`}
+              >
+                코딩 채점
+              </button>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -311,6 +396,7 @@ export const OboEditorSection = React.memo(function OboEditorSection({
           activeEdgeType={activeEdgeType}
           onSelect={handleSelect}
           activeTab={activeTab}
+          frames={frames}
           previewFrame={previewFrame}
           onFrameNodeClick={handleFrameNodeClick}
           onFrameEdgeClick={handleFrameEdgeClick}
@@ -332,6 +418,7 @@ export const OboEditorSection = React.memo(function OboEditorSection({
           currentEdges={edges}
           onJsonClose={() => setJsonVisible(false)}
           onDelete={deleteSelected}
+          oboMode={mode}
           frames={frames}
           selectedFrameId={selectedFrameId}
           onSelectFrame={setSelectedFrameId}
@@ -340,6 +427,14 @@ export const OboEditorSection = React.memo(function OboEditorSection({
           onUpdateFrameLabel={updateFrameLabel}
           onRemoveHighlightNode={removeHighlightNode}
           onRemoveHighlightEdge={removeHighlightEdge}
+          onAddNodeOverride={addNodeOverride}
+          onRemoveNodeOverride={removeNodeOverride}
+          onSetOverrideField={setOverrideField}
+          onClearOverrideField={clearOverrideField}
+          onUpdateFrameCursorTime={updateFrameCursorTime}
+          traceText={traceText}
+          onTraceTextChange={setTraceText}
+          testcaseOutputs={testcaseOutputs}
         />
       </div>
 

--- a/components/obo/OboPlayer.tsx
+++ b/components/obo/OboPlayer.tsx
@@ -12,43 +12,51 @@ import {
 import '@xyflow/react/dist/style.css';
 import { SkipBack, ChevronLeft, ChevronRight, Play, Pause, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { Node } from '@xyflow/react';
 import { nodeTypes } from './nodes';
 import { OboEdge } from './edges/OboEdge';
 import { FrameContext } from './FrameContext';
+import { applyFrame } from './lib/applyFrame';
 import type { OboBlob, Frame } from './types';
 
 const edgeTypes = { 'obo-edge': OboEdge } as const;
 
 interface OboPlayerProps {
   blob: OboBlob;
+  maxFrameIndex?: number;
+  checkpointStatusByFrame?: Record<string, Record<string, 'correct' | 'incorrect'>>;
+  autoPlay?: boolean;
 }
 
-function PlayerInner({ blob }: OboPlayerProps) {
+function PlayerInner({ blob, maxFrameIndex, checkpointStatusByFrame, autoPlay }: OboPlayerProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [playing, setPlaying] = useState(false);
+  const [playing, setPlaying] = useState(autoPlay ?? false);
 
   const frames: Frame[] = blob.frames ?? [];
   const hasFrames = frames.length > 0;
   const currentFrame: Frame | null = hasFrames ? frames[currentIndex] : null;
+  const effectiveLastIndex = maxFrameIndex ?? frames.length - 1;
 
   useEffect(() => {
     if (!playing) return;
-    if (currentIndex >= frames.length - 1) { setPlaying(false); return; }
+    if (currentIndex >= effectiveLastIndex) { setPlaying(false); return; }
     const timer = setTimeout(() => setCurrentIndex(i => i + 1), 1200);
     return () => clearTimeout(timer);
-  }, [playing, currentIndex, frames.length]);
+  }, [playing, currentIndex, effectiveLastIndex]);
 
-  const nodes = blob.nodes.map(n => ({ ...n, selectable: false, draggable: false }));
+  const nodes = applyFrame(blob.nodes as Node[], frames, hasFrames ? currentIndex : -1)
+    .map(n => ({ ...n, selectable: false, draggable: false }));
   const edges = blob.edges.map(e => ({ ...e, type: 'obo-edge' as const, selectable: false }));
 
   const prev = () => { setCurrentIndex(i => Math.max(0, i - 1)); setPlaying(false); };
-  const next = () => { setCurrentIndex(i => Math.min(frames.length - 1, i + 1)); setPlaying(false); };
+  const next = () => { setCurrentIndex(i => Math.min(effectiveLastIndex, i + 1)); setPlaying(false); };
   const reset = () => { setCurrentIndex(0); setPlaying(false); };
+  const checkpointStatus = currentFrame ? checkpointStatusByFrame?.[currentFrame.id] : undefined;
 
   return (
     <div className="flex flex-col h-full rounded-2xl overflow-hidden border border-slate-100 bg-white">
       <div className="flex-1 relative">
-        <FrameContext.Provider value={{ previewFrame: currentFrame }}>
+        <FrameContext.Provider value={{ previewFrame: currentFrame, checkpointStatus }}>
           <ReactFlow
             nodes={nodes}
             edges={edges}
@@ -100,25 +108,30 @@ function PlayerInner({ blob }: OboPlayerProps) {
               </Button>
 
               <div className="flex gap-1.5 px-2">
-                {frames.map((_, i) => (
-                  <button
-                    key={i}
-                    onClick={() => { setCurrentIndex(i); setPlaying(false); }}
-                    className="rounded-full transition-all duration-300"
-                    style={{
-                      width: i === currentIndex ? 28 : 10,
-                      height: 10,
-                      background: i === currentIndex ? '#4f46e5' : i < currentIndex ? '#4f46e566' : '#e2e8f0',
-                    }}
-                  />
-                ))}
+                {frames.map((_, i) => {
+                  const locked = i > effectiveLastIndex;
+                  return (
+                    <button
+                      key={i}
+                      onClick={() => { if (locked) return; setCurrentIndex(i); setPlaying(false); }}
+                      disabled={locked}
+                      className="rounded-full transition-all duration-300 disabled:cursor-not-allowed"
+                      style={{
+                        width: i === currentIndex ? 28 : 10,
+                        height: 10,
+                        opacity: locked ? 0.4 : 1,
+                        background: i === currentIndex ? '#4f46e5' : i < currentIndex ? '#4f46e566' : '#e2e8f0',
+                      }}
+                    />
+                  );
+                })}
               </div>
 
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={next}
-                disabled={currentIndex === frames.length - 1}
+                disabled={currentIndex >= effectiveLastIndex}
                 className="rounded-xl text-slate-400 hover:text-slate-900 h-8 w-8"
               >
                 <ChevronRight className="w-4 h-4" />
@@ -128,7 +141,7 @@ function PlayerInner({ blob }: OboPlayerProps) {
             <Button
               size="icon"
               onClick={() => setPlaying(p => !p)}
-              disabled={currentIndex === frames.length - 1 && !playing}
+              disabled={currentIndex >= effectiveLastIndex && !playing}
               className={`rounded-xl h-9 w-9 shadow-lg transition-all ${playing ? "bg-rose-500 hover:bg-rose-600 shadow-rose-200" : "bg-indigo-600 hover:bg-indigo-700 shadow-indigo-200"}`}
             >
               {playing ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
@@ -150,10 +163,15 @@ function PlayerInner({ blob }: OboPlayerProps) {
   );
 }
 
-export function OboPlayer({ blob }: OboPlayerProps) {
+export function OboPlayer({ blob, maxFrameIndex, checkpointStatusByFrame, autoPlay }: OboPlayerProps) {
   return (
     <ReactFlowProvider>
-      <PlayerInner blob={blob} />
+      <PlayerInner
+        blob={blob}
+        maxFrameIndex={maxFrameIndex}
+        checkpointStatusByFrame={checkpointStatusByFrame}
+        autoPlay={autoPlay}
+      />
     </ReactFlowProvider>
   );
 }

--- a/components/obo/edges/OboEdge.tsx
+++ b/components/obo/edges/OboEdge.tsx
@@ -8,7 +8,7 @@ interface OboEdgeData {
   direction?: 'forward' | 'both';
   style?: 'solid' | 'dashed';
   role?: 'transition' | 'request' | 'allocation';
-  highlight?: boolean;
+  emphasize?: boolean;
 }
 
 export function OboEdge({
@@ -27,7 +27,7 @@ export function OboEdge({
   const frameDimmed = previewFrame !== null && !frameHighlighted;
 
   // 데모(app/challenges/obo/page.tsx)와 동일하게: 평소엔 옅은 회색, 활성(하이라이트)일 때만 두껍고 진하게.
-  const stroke = frameHighlighted ? '#f59e0b' : d.highlight ? '#ef4444' : selected ? '#6366f1' : '#e2e8f0';
+  const stroke = frameHighlighted ? '#f59e0b' : d.emphasize ? '#ef4444' : selected ? '#6366f1' : '#e2e8f0';
   const strokeWidth = frameHighlighted ? 3.5 : selected ? 2.5 : 2;
   const strokeDasharray = d.style === 'dashed' ? '6 3' : undefined;
   const opacity = frameDimmed ? 0.25 : 1;

--- a/components/obo/lib/applyFrame.test.ts
+++ b/components/obo/lib/applyFrame.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import type { Frame } from '../types';
+import { applyFrame } from './applyFrame';
+
+function slotGridNode(id: string): Node {
+  return {
+    id,
+    type: 'slot-grid',
+    position: { x: 0, y: 0 },
+    data: { slotCount: 3, slots: [null, null, null], faultSlotIndex: null, hitSlotIndex: null },
+  };
+}
+
+function frame(id: string, overrides?: Frame['nodeDataOverrides']): Frame {
+  return { id, label: '', highlightNodes: [], highlightEdges: [], nodeDataOverrides: overrides };
+}
+
+describe('applyFrame', () => {
+  it('carries forward state fields not mentioned in later frames', () => {
+    const nodes = [slotGridNode('n_1')];
+    const frames: Frame[] = [
+      frame('f_1', { n_1: { slots: [7, null, null] } }),
+      frame('f_2', {}), // slots 언급 안 됨 → 이전 값 유지
+    ];
+    const result = applyFrame(nodes, frames, 1);
+    expect((result[0].data as any).slots).toEqual([7, null, null]);
+  });
+
+  it('replaces array fields whole-key, not partial patch', () => {
+    const nodes = [slotGridNode('n_1')];
+    const frames: Frame[] = [
+      frame('f_1', { n_1: { slots: [7, 3, null] } }),
+      frame('f_2', { n_1: { slots: [7, null, null] } }), // index 1 통째로 사라짐
+    ];
+    const result = applyFrame(nodes, frames, 1);
+    expect((result[0].data as any).slots).toEqual([7, null, null]);
+  });
+
+  it('resets event fields to null every frame unless overridden this frame', () => {
+    const nodes = [slotGridNode('n_1')];
+    const frames: Frame[] = [
+      frame('f_1', { n_1: { faultSlotIndex: 0 } }),
+      frame('f_2', {}), // faultSlotIndex 미언급 → null로 리셋
+    ];
+    const atF1 = applyFrame(nodes, frames, 0);
+    expect((atF1[0].data as any).faultSlotIndex).toBe(0);
+
+    const atF2 = applyFrame(nodes, frames, 1);
+    expect((atF2[0].data as any).faultSlotIndex).toBeNull();
+  });
+
+  it('returns base data untouched when currentFrameIndex is -1', () => {
+    const nodes = [slotGridNode('n_1')];
+    const frames: Frame[] = [frame('f_1', { n_1: { slots: [9, null, null] } })];
+    const result = applyFrame(nodes, frames, -1);
+    expect((result[0].data as any).slots).toEqual([null, null, null]);
+  });
+});

--- a/components/obo/lib/applyFrame.ts
+++ b/components/obo/lib/applyFrame.ts
@@ -1,0 +1,23 @@
+import type { Node } from '@xyflow/react';
+import type { Frame } from '../types';
+import { getEventFields } from './overrideFields';
+
+/**
+ * frames[0..currentFrameIndex]를 순서대로 fold하여 각 노드의 effective data를 계산한다.
+ * - state 필드: 명시적으로 override되지 않으면 이전 값 유지(carry-forward)
+ * - event 필드: 매 프레임 시작 시 null로 리셋 후 해당 프레임 override만 반영
+ * - override는 키 단위 전체 교체(부분 patch 아님)
+ */
+export function applyFrame(baseNodes: Node[], frames: Frame[], currentFrameIndex: number): Node[] {
+  const relevant = frames.slice(0, currentFrameIndex + 1);
+  return baseNodes.map(node => {
+    const eventFields = getEventFields(node.type);
+    let acc: Record<string, unknown> = { ...(node.data as Record<string, unknown>) };
+    for (const frame of relevant) {
+      for (const f of eventFields) acc[f] = null;
+      const override = frame.nodeDataOverrides?.[node.id];
+      if (override) acc = { ...acc, ...override };
+    }
+    return { ...node, data: acc };
+  });
+}

--- a/components/obo/lib/codingDiff.test.ts
+++ b/components/obo/lib/codingDiff.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import type { OboCodingSchema, OboTraceStep } from '../types';
+import { buildCodingDiffPlan } from './codingDiff';
+
+function slotGridNode(id: string): Node {
+  return {
+    id,
+    type: 'slot-grid',
+    position: { x: 0, y: 0 },
+    data: { slotCount: 3, slots: [null, null, null], faultSlotIndex: null, hitSlotIndex: null },
+  };
+}
+
+function stateNode(id: string): Node {
+  return { id, type: 'state-node', position: { x: 0, y: 0 }, data: { label: id, shape: 'circle' } };
+}
+
+function edge(id: string, source: string, target: string) {
+  return { id, source, target, sourceHandle: null, targetHandle: null, data: {} };
+}
+
+describe('buildCodingDiffPlan — 값 비교 (FIFO 슬롯)', () => {
+  const nodes = [slotGridNode('n_1')];
+
+  // FIFO 페이지 교체: 같은 노드(n_1)의 같은 필드(slots)가 스텝마다 다른 정답을 가짐
+  const referenceTrace: OboTraceStep[] = [
+    { overrides: { n_1: { slots: [7, null, null] } }, highlightNodes: [] },
+    { overrides: { n_1: { slots: [7, 0, null] } }, highlightNodes: [] },
+    { overrides: { n_1: { slots: [7, 0, 1] } }, highlightNodes: [] },
+  ];
+
+  function schema(trace = referenceTrace): OboCodingSchema {
+    return { nodes, edges: [], referenceTrace: trace };
+  }
+
+  it('all correct → plays through every step to the last one', () => {
+    const plan = buildCodingDiffPlan(schema(), referenceTrace);
+    expect(plan.stopAtFrameIndex).toBe(2);
+    expect(plan.statusByFrameId['f_1'].n_1).toBe('correct');
+    expect(plan.statusByFrameId['f_2'].n_1).toBe('correct');
+    expect(plan.statusByFrameId['f_3'].n_1).toBe('correct');
+  });
+
+  it('carries forward a step that omits the field, same as Frame.nodeDataOverrides', () => {
+    const traceWithCarryForward: OboTraceStep[] = [
+      { overrides: { n_1: { slots: [7, null, null] } }, highlightNodes: [] },
+      { overrides: { n_1: { slots: [7, 0, null] } }, highlightNodes: [] },
+      { overrides: {}, highlightNodes: [] }, // slots 생략 → 이전 스텝([7,0,null])에서 carry-forward
+    ];
+    const submitted: OboTraceStep[] = [
+      { overrides: { n_1: { slots: [7, null, null] } }, highlightNodes: [] },
+      { overrides: { n_1: { slots: [7, 0, null] } }, highlightNodes: [] },
+      { overrides: { n_1: { slots: [7, 0, null] } }, highlightNodes: [] }, // 명시적으로 반복 — 값은 같아야 함
+    ];
+    const plan = buildCodingDiffPlan(schema(traceWithCarryForward), submitted);
+    expect(plan.stopAtFrameIndex).toBe(2);
+    expect(plan.statusByFrameId['f_3'].n_1).toBe('correct');
+  });
+
+  it('incorrect at a middle step stops there and does not evaluate later steps', () => {
+    const submitted: OboTraceStep[] = [
+      { overrides: { n_1: { slots: [7, null, null] } }, highlightNodes: [] },
+      { overrides: { n_1: { slots: [7, 9, null] } }, highlightNodes: [] }, // 정답([7,0,null])과 다름
+      { overrides: { n_1: { slots: [7, 0, 1] } }, highlightNodes: [] },
+    ];
+    const plan = buildCodingDiffPlan(schema(), submitted);
+    expect(plan.stopAtFrameIndex).toBe(1);
+    expect(plan.statusByFrameId['f_1'].n_1).toBe('correct');
+    expect(plan.statusByFrameId['f_2'].n_1).toBe('incorrect');
+    expect(plan.statusByFrameId['f_3']).toBeUndefined();
+  });
+
+  it('blob is generated from the submitted trace, not the reference trace', () => {
+    const submitted: OboTraceStep[] = [
+      { overrides: { n_1: { slots: [7, null, null] } }, highlightNodes: [] },
+      { overrides: { n_1: { slots: [7, 9, null] } }, highlightNodes: [] },
+      { overrides: { n_1: { slots: [7, 0, 1] } }, highlightNodes: [] },
+    ];
+    const plan = buildCodingDiffPlan(schema(), submitted);
+    expect(plan.blob.frames[1].nodeDataOverrides?.n_1).toEqual({ slots: [7, 9, null] });
+  });
+});
+
+describe('buildCodingDiffPlan — 강조 집합 비교 (상태 전이)', () => {
+  const nodes = ['new', 'ready', 'running', 'waiting', 'terminated'].map(stateNode);
+  const edges = [
+    edge('e1', 'new', 'ready'),
+    edge('e2', 'ready', 'running'),
+    edge('e3', 'running', 'waiting'),
+    edge('e4', 'running', 'terminated'),
+  ];
+
+  // New → Ready → Running → Terminated
+  const referenceTrace: OboTraceStep[] = [
+    { overrides: {}, highlightNodes: ['new', 'ready'] },
+    { overrides: {}, highlightNodes: ['ready', 'running'] },
+    { overrides: {}, highlightNodes: ['running', 'terminated'] },
+  ];
+
+  function schema(): OboCodingSchema {
+    return { nodes, edges, referenceTrace };
+  }
+
+  it('all correct → highlights match every step, and connecting edges are auto-highlighted', () => {
+    const plan = buildCodingDiffPlan(schema(), referenceTrace);
+    expect(plan.stopAtFrameIndex).toBe(2);
+    expect(plan.statusByFrameId['f_1'].new).toBe('correct');
+    expect(plan.statusByFrameId['f_1'].ready).toBe('correct');
+    expect(plan.blob.frames[0].highlightEdges).toEqual(['e1']);
+    expect(plan.blob.frames[2].highlightEdges).toEqual(['e4']);
+  });
+
+  it('a wrong transition (different node highlighted) stops at that step', () => {
+    const submitted: OboTraceStep[] = [
+      { overrides: {}, highlightNodes: ['new', 'ready'] },
+      { overrides: {}, highlightNodes: ['ready', 'waiting'] }, // 정답은 running인데 waiting으로 잘못 전이
+      { overrides: {}, highlightNodes: ['running', 'terminated'] },
+    ];
+    const plan = buildCodingDiffPlan(schema(), submitted);
+    expect(plan.stopAtFrameIndex).toBe(1);
+    expect(plan.statusByFrameId['f_1'].new).toBe('correct');
+    expect(plan.statusByFrameId['f_2'].ready).toBe('incorrect');
+    expect(plan.statusByFrameId['f_2'].waiting).toBe('incorrect');
+    expect(plan.statusByFrameId['f_3']).toBeUndefined();
+  });
+
+  it('wrong from the first step stops immediately', () => {
+    const submitted: OboTraceStep[] = [
+      { overrides: {}, highlightNodes: ['new', 'waiting'] }, // 정답은 ready
+      { overrides: {}, highlightNodes: ['ready', 'running'] },
+      { overrides: {}, highlightNodes: ['running', 'terminated'] },
+    ];
+    const plan = buildCodingDiffPlan(schema(), submitted);
+    expect(plan.stopAtFrameIndex).toBe(0);
+    expect(plan.statusByFrameId['f_1'].new).toBe('incorrect');
+    expect(plan.statusByFrameId['f_2']).toBeUndefined();
+  });
+});

--- a/components/obo/lib/codingDiff.ts
+++ b/components/obo/lib/codingDiff.ts
@@ -1,0 +1,118 @@
+import type { Node } from '@xyflow/react';
+import type { OboBlob, OboCodingSchema, OboTraceStep } from '../types';
+import { generateFramesFromTrace } from './trace';
+import { resolveFieldValue } from './resolveFieldValue';
+
+export type CheckpointStatus = 'correct' | 'incorrect';
+
+export interface CheckpointEvalResult {
+  frameIndex: number;
+  nodeId: string;
+  field: string; // 값 비교면 실제 필드명, 강조 비교면 '__highlight__'
+  status: CheckpointStatus;
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface CodingDiffPlan {
+  results: CheckpointEvalResult[];
+  stopAtFrameIndex: number;
+  statusByFrameId: Record<string, Record<string, CheckpointStatus>>;
+  blob: OboBlob; // 제출 트레이스로 생성된 blob — 정답이 아니라 실제 제출값/강조가 화면에 보인다
+}
+
+// 값이 slots/blocks 같은 배열/객체일 수 있어 ===(참조 비교)로는 항상 다르다고 판정된다.
+// 전부 채점 API가 반환하는 JSON 직렬화 가능한 데이터이므로 구조적 비교로 처리한다.
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+}
+
+// referenceTrace 전체를 훑어 실제로 값이 등장하는 (nodeId, field) 쌍을 중복 없이 수집한다 —
+// 교사가 별도로 "채점 대상"을 지정할 필요 없이 트레이스 자체가 채점 대상을 정의한다.
+function collectValueFields(trace: OboTraceStep[]): { nodeId: string; field: string }[] {
+  const seen = new Set<string>();
+  const result: { nodeId: string; field: string }[] = [];
+  for (const step of trace) {
+    for (const nodeId of Object.keys(step.overrides)) {
+      for (const field of Object.keys(step.overrides[nodeId])) {
+        const key = `${nodeId}.${field}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          result.push({ nodeId, field });
+        }
+      }
+    }
+  }
+  return result;
+}
+
+export function buildCodingDiffPlan(
+  schema: OboCodingSchema,
+  submittedTrace: OboTraceStep[]
+): CodingDiffPlan {
+  const frames = generateFramesFromTrace(submittedTrace, schema.edges);
+  const referenceFrames = generateFramesFromTrace(schema.referenceTrace, schema.edges);
+  const valueFields = collectValueFields(schema.referenceTrace);
+  const results: CheckpointEvalResult[] = [];
+  const statusByFrameId: Record<string, Record<string, CheckpointStatus>> = {};
+  const compareLength = Math.min(schema.referenceTrace.length, submittedTrace.length);
+  let stopAtFrameIndex = compareLength - 1;
+
+  const setStatus = (frameId: string, nodeId: string, status: CheckpointStatus) => {
+    const existing = statusByFrameId[frameId]?.[nodeId];
+    statusByFrameId[frameId] = {
+      ...(statusByFrameId[frameId] ?? {}),
+      [nodeId]: existing === 'incorrect' ? 'incorrect' : status,
+    };
+  };
+
+  outer: for (let i = 0; i < compareLength; i++) {
+    const frameId = frames[i].id;
+    let frameIncorrect = false;
+
+    // 트랙 1: 값 비교 (carry-forward 적용 — 트레이스 스텝이 부분 표기일 수 있으므로 applyFrame 규칙을 그대로 태운다)
+    for (const vf of valueFields) {
+      const expected = resolveFieldValue(schema.nodes as Node[], referenceFrames, i, vf.nodeId, vf.field);
+      const actual = resolveFieldValue(schema.nodes as Node[], frames, i, vf.nodeId, vf.field);
+      const status: CheckpointStatus = valuesEqual(actual, expected) ? 'correct' : 'incorrect';
+
+      results.push({ frameIndex: i, nodeId: vf.nodeId, field: vf.field, status, expected, actual });
+      setStatus(frameId, vf.nodeId, status);
+      if (status === 'incorrect') frameIncorrect = true;
+    }
+
+    // 트랙 2: 강조 노드 집합 비교 (carry-forward 없음 — 그 스텝의 강조 배열 그대로 비교)
+    const refHighlight = schema.referenceTrace[i]?.highlightNodes ?? [];
+    const subHighlight = submittedTrace[i]?.highlightNodes ?? [];
+    const highlightUnion = new Set([...refHighlight, ...subHighlight]);
+    if (highlightUnion.size > 0) {
+      const highlightMatches = sameSet(refHighlight, subHighlight);
+      const status: CheckpointStatus = highlightMatches ? 'correct' : 'incorrect';
+      for (const nodeId of highlightUnion) {
+        results.push({ frameIndex: i, nodeId, field: '__highlight__', status, expected: refHighlight, actual: subHighlight });
+        setStatus(frameId, nodeId, status);
+      }
+      if (!highlightMatches) frameIncorrect = true;
+    }
+
+    if (frameIncorrect) {
+      stopAtFrameIndex = i;
+      break outer;
+    }
+  }
+
+  return {
+    results,
+    stopAtFrameIndex,
+    statusByFrameId,
+    blob: { nodes: schema.nodes, edges: schema.edges, frames },
+  };
+}

--- a/components/obo/lib/id.ts
+++ b/components/obo/lib/id.ts
@@ -1,0 +1,17 @@
+function nextSequentialId(prefix: 'n' | 'e' | 'f', ids: string[]): string {
+  const re = new RegExp(`^${prefix}_(\\d+)$`);
+  const max = ids.reduce((m, id) => {
+    const match = re.exec(id);
+    return match ? Math.max(m, parseInt(match[1], 10)) : m;
+  }, 0);
+  return `${prefix}_${max + 1}`;
+}
+
+export const nextNodeId = (nodes: { id: string }[]): string =>
+  nextSequentialId('n', nodes.map(n => n.id));
+
+export const nextEdgeId = (edges: { id: string }[]): string =>
+  nextSequentialId('e', edges.map(e => e.id));
+
+export const nextFrameId = (frames: { id: string }[]): string =>
+  nextSequentialId('f', frames.map(f => f.id));

--- a/components/obo/lib/overrideFields.test.ts
+++ b/components/obo/lib/overrideFields.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import { exampleStateValue } from './overrideFields';
+
+function node(type: string, data: Record<string, unknown>): Node {
+  return { id: 'x', type, position: { x: 0, y: 0 }, data };
+}
+
+describe('exampleStateValue', () => {
+  it('text-label → quoted string, falling back to a default when text is empty', () => {
+    expect(typeof JSON.parse(exampleStateValue(node('text-label', { text: '' }))!)).toBe('string');
+    expect(JSON.parse(exampleStateValue(node('text-label', { text: 'hi' }))!)).toBe('hi');
+  });
+
+  it('counter-badge → a plain number', () => {
+    const parsed = JSON.parse(exampleStateValue(node('counter-badge', { value: 5 }))!);
+    expect(typeof parsed).toBe('number');
+    expect(parsed).toBe(5);
+  });
+
+  it('slot-grid → an array of null matching slotCount', () => {
+    const parsed = JSON.parse(exampleStateValue(node('slot-grid', { slotCount: 4 }))!);
+    expect(parsed).toEqual([null, null, null, null]);
+  });
+
+  it('slot-grid falls back to slots.length when slotCount is missing', () => {
+    const parsed = JSON.parse(exampleStateValue(node('slot-grid', { slots: [1, 2] }))!);
+    expect(parsed).toHaveLength(2);
+  });
+
+  it('gantt-lane → an array containing one block-shaped object', () => {
+    const parsed = JSON.parse(exampleStateValue(node('gantt-lane', {}))!);
+    expect(parsed).toEqual([{ start: expect.any(Number), end: expect.any(Number), colorKey: expect.any(String) }]);
+  });
+
+  it('node types with no state field return null', () => {
+    expect(exampleStateValue(node('state-node', {}))).toBeNull();
+    expect(exampleStateValue(node('resource-square', {}))).toBeNull();
+    expect(exampleStateValue(node('line-chart', {}))).toBeNull();
+  });
+});

--- a/components/obo/lib/overrideFields.ts
+++ b/components/obo/lib/overrideFields.ts
@@ -1,0 +1,44 @@
+import type { Node } from '@xyflow/react';
+import { DEFAULT_TIMELINE_COLOR_KEY } from '../nodes/ganttColors';
+
+export const NODE_OVERRIDE_FIELDS: Record<string, { state: string[]; event: string[] }> = {
+  'text-label':    { state: ['text'],   event: [] },
+  'gantt-lane':    { state: ['blocks'], event: ['activeBlockIndex'] },
+  'slot-grid':     { state: ['slots'],  event: ['faultSlotIndex', 'hitSlotIndex'] },
+  'counter-badge': { state: ['value'],  event: ['delta'] },
+};
+
+export const OVERRIDABLE_NODE_TYPES = Object.keys(NODE_OVERRIDE_FIELDS);
+
+export function getEventFields(nodeType: string | undefined): string[] {
+  return nodeType ? NODE_OVERRIDE_FIELDS[nodeType]?.event ?? [] : [];
+}
+
+export function getStateFields(nodeType: string | undefined): string[] {
+  return nodeType ? NODE_OVERRIDE_FIELDS[nodeType]?.state ?? [] : [];
+}
+
+export function isOverridableNodeType(nodeType: string | undefined): boolean {
+  return !!nodeType && nodeType in NODE_OVERRIDE_FIELDS;
+}
+
+// 그 노드의 state 필드에 바로 써넣을 수 있는 예시 값(JSON 문자열). 어떤 템플릿을 섞어 쓰든
+// 실제 캔버스에 있는 노드의 현재 data를 기준으로 계산하므로 항상 정확하다.
+// state 필드가 없는 타입(state-node 등, 값이 아니라 강조 이동만 있는 노드)은 null.
+export function exampleStateValue(node: Node): string | null {
+  const data = (node.data ?? {}) as Record<string, unknown>;
+  switch (node.type) {
+    case 'text-label':
+      return JSON.stringify((data.text as string) || '텍스트');
+    case 'counter-badge':
+      return JSON.stringify((data.value as number) ?? 0);
+    case 'slot-grid': {
+      const count = (data.slotCount as number) ?? (data.slots as unknown[] | undefined)?.length ?? 3;
+      return JSON.stringify(Array(count).fill(null));
+    }
+    case 'gantt-lane':
+      return JSON.stringify([{ start: 0, end: 1, colorKey: DEFAULT_TIMELINE_COLOR_KEY }]);
+    default:
+      return null;
+  }
+}

--- a/components/obo/lib/resolveFieldValue.ts
+++ b/components/obo/lib/resolveFieldValue.ts
@@ -1,0 +1,14 @@
+import type { Node } from '@xyflow/react';
+import type { Frame } from '../types';
+import { applyFrame } from './applyFrame';
+
+export function resolveFieldValue(
+  baseNodes: Node[],
+  frames: Frame[],
+  frameIndex: number,
+  nodeId: string,
+  field: string
+): unknown {
+  const node = applyFrame(baseNodes, frames, frameIndex).find(n => n.id === nodeId);
+  return (node?.data as Record<string, unknown> | undefined)?.[field];
+}

--- a/components/obo/lib/trace.test.ts
+++ b/components/obo/lib/trace.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import type { OboBlob, OboTraceStep } from '../types';
+import { generateFramesFromTrace } from './trace';
+
+function edge(id: string, source: string, target: string, direction?: 'forward' | 'both'): OboBlob['edges'][number] {
+  return { id, source, target, sourceHandle: null, targetHandle: null, data: { direction } };
+}
+
+describe('generateFramesFromTrace — highlightEdges', () => {
+  it('only highlights the edge matching the trace order, not the reverse-direction parallel edge', () => {
+    // ready<->running 사이에 서로 다른 방향의 엣지 두 개(dispatch: ready->running, interrupt: running->ready)
+    const edges = [
+      edge('dispatch', 'ready', 'running'),
+      edge('interrupt', 'running', 'ready'),
+    ];
+    const trace: OboTraceStep[] = [{ overrides: {}, highlightNodes: ['ready', 'running'] }];
+    const frames = generateFramesFromTrace(trace, edges);
+    expect(frames[0].highlightEdges).toEqual(['dispatch']);
+  });
+
+  it('picks the reverse-order edge when the trace lists nodes in the opposite direction', () => {
+    const edges = [
+      edge('dispatch', 'ready', 'running'),
+      edge('interrupt', 'running', 'ready'),
+    ];
+    const trace: OboTraceStep[] = [{ overrides: {}, highlightNodes: ['running', 'ready'] }];
+    const frames = generateFramesFromTrace(trace, edges);
+    expect(frames[0].highlightEdges).toEqual(['interrupt']);
+  });
+
+  it('a bidirectional (direction: "both") edge matches regardless of trace order', () => {
+    const edges = [edge('e1', 'a', 'b', 'both')];
+    const forward = generateFramesFromTrace([{ overrides: {}, highlightNodes: ['a', 'b'] }], edges);
+    const backward = generateFramesFromTrace([{ overrides: {}, highlightNodes: ['b', 'a'] }], edges);
+    expect(forward[0].highlightEdges).toEqual(['e1']);
+    expect(backward[0].highlightEdges).toEqual(['e1']);
+  });
+
+  it('a forward-only edge does not match when traversed in reverse', () => {
+    const edges = [edge('e1', 'a', 'b', 'forward')];
+    const backward = generateFramesFromTrace([{ overrides: {}, highlightNodes: ['b', 'a'] }], edges);
+    expect(backward[0].highlightEdges).toEqual([]);
+  });
+});

--- a/components/obo/lib/trace.ts
+++ b/components/obo/lib/trace.ts
@@ -1,0 +1,32 @@
+import type { Frame, OboBlob, OboTraceStep } from '../types';
+
+// 트레이스 줄에서 노드 id가 등장한 순서를 "from -> to" 방향으로 간주해 그 방향의 엣지만 찾는다.
+// 두 노드가 강조됐다고 그 사이 엣지를 전부(양방향 엣지, 병렬 엣지 포함) 강조하면 예를 들어
+// ready<->running처럼 서로 다른 방향의 엣지(dispatch/interrupt)가 둘 다 있는 경우 둘 다 켜지는
+// 문제가 생긴다 — 트레이스가 준 순서를 방향으로 써서 정확히 그 전이 하나만 고른다.
+function findDirectedEdge(edges: OboBlob['edges'], from: string, to: string) {
+  return edges.find(e => {
+    if (e.source === from && e.target === to) return true;
+    const direction = (e.data as { direction?: string } | undefined)?.direction;
+    return direction === 'both' && e.source === to && e.target === from;
+  });
+}
+
+// 트레이스(정답 실행 트레이스 또는 제출 실행 트레이스)를 재생 가능한 프레임 배열로 변환.
+// 한 스텝 = 한 프레임. highlightNodes에서 연속된 두 노드 사이에 그 방향의 엣지가 있으면 강조한다.
+export function generateFramesFromTrace(trace: OboTraceStep[], edges: OboBlob['edges']): Frame[] {
+  return trace.map((step, i) => {
+    const highlightEdges: string[] = [];
+    for (let j = 0; j < step.highlightNodes.length - 1; j++) {
+      const match = findDirectedEdge(edges, step.highlightNodes[j], step.highlightNodes[j + 1]);
+      if (match) highlightEdges.push(match.id);
+    }
+    return {
+      id: `f_${i + 1}`,
+      label: `스텝 ${i + 1}`,
+      highlightNodes: step.highlightNodes,
+      highlightEdges,
+      nodeDataOverrides: step.overrides,
+    };
+  });
+}

--- a/components/obo/lib/traceParser.test.ts
+++ b/components/obo/lib/traceParser.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import type { Node } from '@xyflow/react';
+import { parseTraceText, stringifyTrace } from './traceParser';
+
+function stateNode(id: string): Node {
+  return { id, type: 'state-node', position: { x: 0, y: 0 }, data: { label: id, shape: 'circle' } };
+}
+
+function counterNode(id: string): Node {
+  return { id, type: 'counter-badge', position: { x: 0, y: 0 }, data: { label: id, min: 0, max: 10, value: 0 } };
+}
+
+describe('parseTraceText', () => {
+  it('parses consecutive node-id tokens as a highlight-only step (state transition)', () => {
+    const nodes = ['sn_1', 'sn_2', 'sn_3', 'sn_4', 'sn_5'].map(stateNode);
+    const text = 'sn_1 sn_2\nsn_2 sn_3\nsn_3 sn_5';
+    const steps = parseTraceText(text, nodes);
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toEqual({ overrides: {}, highlightNodes: ['sn_1', 'sn_2'] });
+    expect(steps[1]).toEqual({ overrides: {}, highlightNodes: ['sn_2', 'sn_3'] });
+    expect(steps[2]).toEqual({ overrides: {}, highlightNodes: ['sn_3', 'sn_5'] });
+  });
+
+  it('parses "nodeId value" tokens as a field assignment', () => {
+    const nodes = ['n_1', 'n_2', 'n_3'].map(counterNode);
+    const text = 'n_1 3\nn_2 3\nn_3 4';
+    const steps = parseTraceText(text, nodes);
+    expect(steps).toHaveLength(3);
+    expect(steps[0]).toEqual({ overrides: { n_1: { value: 3 } }, highlightNodes: ['n_1'] });
+    expect(steps[1]).toEqual({ overrides: { n_2: { value: 3 } }, highlightNodes: ['n_2'] });
+    expect(steps[2]).toEqual({ overrides: { n_3: { value: 4 } }, highlightNodes: ['n_3'] });
+  });
+
+  it('handles a mixed line with both a value assignment and highlight-only nodes', () => {
+    const nodes = [counterNode('n_1'), stateNode('sn_1'), stateNode('sn_2')];
+    const steps = parseTraceText('n_1 3 sn_1 sn_2', nodes);
+    expect(steps).toEqual([{ overrides: { n_1: { value: 3 } }, highlightNodes: ['n_1', 'sn_1', 'sn_2'] }]);
+  });
+
+  it('ignores blank lines', () => {
+    const nodes = ['sn_1', 'sn_2'].map(stateNode);
+    const steps = parseTraceText('sn_1 sn_2\n\n\nsn_2 sn_1', nodes);
+    expect(steps).toHaveLength(2);
+  });
+
+  it('parses array-valued fields as a single bracketed token (no internal spaces)', () => {
+    const slotGrid: Node = {
+      id: 'frames', type: 'slot-grid', position: { x: 0, y: 0 },
+      data: { slotCount: 3, slots: [null, null, null], faultSlotIndex: null, hitSlotIndex: null },
+    };
+    const steps = parseTraceText('frames [7,null,null]', [slotGrid]);
+    expect(steps[0].overrides.frames.slots).toEqual([7, null, null]);
+  });
+
+  it('silently ignores a value token following a node with no state field', () => {
+    const nodes = [stateNode('sn_1')];
+    const steps = parseTraceText('sn_1 3', nodes);
+    expect(steps).toEqual([{ overrides: {}, highlightNodes: ['sn_1'] }]);
+  });
+});
+
+describe('stringifyTrace', () => {
+  it('round-trips highlight-only steps', () => {
+    const nodes = ['sn_1', 'sn_2', 'sn_3', 'sn_5'].map(stateNode);
+    const steps = parseTraceText('sn_1 sn_2\nsn_2 sn_3\nsn_3 sn_5', nodes);
+    const restored = stringifyTrace(steps, nodes);
+    expect(parseTraceText(restored, nodes)).toEqual(steps);
+  });
+
+  it('round-trips value-based steps', () => {
+    const nodes = ['n_1', 'n_2'].map(counterNode);
+    const steps = parseTraceText('n_1 3\nn_2 4', nodes);
+    const restored = stringifyTrace(steps, nodes);
+    expect(parseTraceText(restored, nodes)).toEqual(steps);
+  });
+});

--- a/components/obo/lib/traceParser.ts
+++ b/components/obo/lib/traceParser.ts
@@ -1,0 +1,75 @@
+import type { Node } from '@xyflow/react';
+import type { OboTraceStep } from '../types';
+import { getStateFields } from './overrideFields';
+
+function parseValueToken(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+// 한 줄 = 한 스텝. 토큰이 노드 id면 그 스텝에서 강조 대상으로, 노드 id가 아니면(값이면)
+// 바로 앞에 나온 노드 id의 유일한 state 필드에 배정한다. state 필드가 없는 노드(state-node 등)
+// 뒤에 값 토큰이 오면 배정할 필드가 없으므로 조용히 무시한다.
+export function parseTraceText(text: string, nodes: Node[]): OboTraceStep[] {
+  const nodeTypeById = new Map(nodes.map(n => [n.id, n.type]));
+
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .map(line => {
+      const tokens = line.split(/\s+/);
+      const overrides: Record<string, Record<string, unknown>> = {};
+      const highlightNodes: string[] = [];
+      let lastNodeId: string | null = null;
+
+      for (const token of tokens) {
+        if (nodeTypeById.has(token)) {
+          highlightNodes.push(token);
+          lastNodeId = token;
+          continue;
+        }
+        if (lastNodeId) {
+          const field = getStateFields(nodeTypeById.get(lastNodeId))[0];
+          if (field) {
+            overrides[lastNodeId] = { ...(overrides[lastNodeId] ?? {}), [field]: parseValueToken(token) };
+          }
+        }
+      }
+
+      return { overrides, highlightNodes };
+    });
+}
+
+// parseTraceText의 역변환 — 저장된 구조화 트레이스를 편집용 텍스트로 되돌린다
+// (기존 문제를 에디터에서 다시 열었을 때 textarea 초기값 복원용).
+export function stringifyTrace(trace: OboTraceStep[], nodes: Node[]): string {
+  const nodeTypeById = new Map(nodes.map(n => [n.id, n.type]));
+
+  return trace
+    .map(step => {
+      const parts: string[] = [];
+      const covered = new Set<string>();
+
+      for (const nodeId of step.highlightNodes) {
+        parts.push(nodeId);
+        const field = getStateFields(nodeTypeById.get(nodeId))[0];
+        const value = field ? step.overrides[nodeId]?.[field] : undefined;
+        if (value !== undefined) parts.push(JSON.stringify(value));
+        covered.add(nodeId);
+      }
+
+      for (const nodeId of Object.keys(step.overrides)) {
+        if (covered.has(nodeId)) continue;
+        const field = getStateFields(nodeTypeById.get(nodeId))[0];
+        const value = field ? step.overrides[nodeId]?.[field] : undefined;
+        if (value !== undefined) parts.push(nodeId, JSON.stringify(value));
+      }
+
+      return parts.join(' ');
+    })
+    .join('\n');
+}

--- a/components/obo/nodes/CheckpointStatusRing.tsx
+++ b/components/obo/nodes/CheckpointStatusRing.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+const COLORS = { correct: '#1D9E75', incorrect: '#E24B4A' } as const;
+
+interface CheckpointStatusRingProps {
+  status: 'correct' | 'incorrect' | null | undefined;
+  children: ReactNode;
+}
+
+export function CheckpointStatusRing({ status, children }: CheckpointStatusRingProps) {
+  if (!status) return <>{children}</>;
+
+  const color = COLORS[status];
+
+  return (
+    <div style={{ position: 'relative', display: 'inline-flex' }}>
+      <div
+        style={{
+          position: 'absolute',
+          inset: -4,
+          borderRadius: 12,
+          border: `2.5px solid ${color}`,
+          boxShadow: `0 0 0 3px ${color}30`,
+          pointerEvents: 'none',
+        }}
+      />
+      {children}
+      <span
+        style={{
+          position: 'absolute',
+          top: -8,
+          right: -8,
+          width: 16,
+          height: 16,
+          borderRadius: '50%',
+          background: color,
+          color: 'white',
+          fontSize: 10,
+          fontWeight: 900,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          lineHeight: 1,
+        }}
+      >
+        {status === 'correct' ? '✓' : '✗'}
+      </span>
+    </div>
+  );
+}

--- a/components/obo/nodes/CounterBadgeNode.tsx
+++ b/components/obo/nodes/CounterBadgeNode.tsx
@@ -1,30 +1,46 @@
 'use client';
 
 import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { useFrameCtx } from '../FrameContext';
+import { CheckpointStatusRing } from './CheckpointStatusRing';
 
-interface CounterBadgeNodeData {
-  label: string;
-  key?: string;
+interface CounterBadgeData {
+  label?: string;
+  min?: number;
+  max?: number;
   value?: number;
-  color?: string;
+  delta?: number | null;
 }
 
-export function CounterBadgeNode({ data, selected }: NodeProps) {
-  const d = data as unknown as CounterBadgeNodeData;
-  const color = d.color ?? '#b45309';
+const COLOR = '#b45309';
+
+export function CounterBadgeNode({ id, data, selected }: NodeProps) {
+  const d = data as unknown as CounterBadgeData;
+  const value = d.value ?? 0;
+  const delta = d.delta ?? null;
+  const { checkpointStatus } = useFrameCtx();
+  const status = checkpointStatus?.[id] ?? null;
+
   return (
-    <div style={{
-      display: 'inline-flex', alignItems: 'center', gap: 4,
-      padding: '4px 10px', borderRadius: 9999,
-      border: `1.5px solid ${color}`, backgroundColor: 'white',
-      boxShadow: selected ? `0 0 0 3px ${color}40` : '0 1px 4px rgba(0,0,0,0.08)',
-      cursor: 'grab', userSelect: 'none',
-    }}>
-      <Handle id="l" type="target" position={Position.Left}  style={{ background: color, border: 'none' }} />
-      <Handle id="r" type="source" position={Position.Right} style={{ background: color, border: 'none' }} />
-      <span style={{ fontSize: 12, fontWeight: 700, color }}>{d.key ?? d.label}</span>
-      <span style={{ fontSize: 11, color: '#94a3b8' }}>=</span>
-      <span style={{ fontSize: 12, fontWeight: 700, color }}>{d.value ?? 0}</span>
-    </div>
+    <CheckpointStatusRing status={status}>
+      <div style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4,
+        padding: '4px 10px', borderRadius: 9999,
+        border: `1.5px solid ${COLOR}`, backgroundColor: 'white',
+        boxShadow: selected ? `0 0 0 3px ${COLOR}40` : '0 1px 4px rgba(0,0,0,0.08)',
+        cursor: 'grab', userSelect: 'none',
+      }}>
+        <Handle id="l" type="target" position={Position.Left}  style={{ background: COLOR, border: 'none' }} />
+        <Handle id="r" type="source" position={Position.Right} style={{ background: COLOR, border: 'none' }} />
+        <span style={{ fontSize: 12, fontWeight: 700, color: COLOR }}>{d.label ?? ''}</span>
+        <span style={{ fontSize: 11, color: '#94a3b8' }}>=</span>
+        <span style={{ fontSize: 12, fontWeight: 700, color: COLOR }}>{value}</span>
+        {delta != null && (
+          <span style={{ fontSize: 10, fontWeight: 700, color: delta > 0 ? '#1D9E75' : '#E24B4A' }}>
+            {delta > 0 ? `+${delta}` : delta}
+          </span>
+        )}
+      </div>
+    </CheckpointStatusRing>
   );
 }

--- a/components/obo/nodes/GanttLane.tsx
+++ b/components/obo/nodes/GanttLane.tsx
@@ -1,108 +1,101 @@
 'use client';
 
 import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { TIMELINE_COLOR_PALETTE, DEFAULT_TIMELINE_COLOR_KEY } from './ganttColors';
+import { useFrameCtx } from '../FrameContext';
+import { CheckpointStatusRing } from './CheckpointStatusRing';
 
-interface GanttBlock {
-  label: string;
+interface TimelineBlock {
   start: number;
   end: number;
-  color?: string;
+  colorKey: string;
 }
 
-interface GanttLaneData {
-  label?: string;
-  mode?: 'block' | 'step';
-  axisMax?: number;
-  blocks?: GanttBlock[];
+interface TimelineBlockData {
+  trackId?: string;
+  blocks?: TimelineBlock[];
+  activeBlockIndex?: number | null;
 }
 
-const SCALE = 20; // px per time unit
-const DEFAULT_COLOR = '#1D9E75';
+const SCALE = 26; // px per time unit
+const TRACK_H = 40;
 
-function BlockMode({ d, selected }: { d: GanttLaneData; selected: boolean }) {
-  const axisMax = d.axisMax ?? 8;
+function colorFor(colorKey: string): string {
+  return TIMELINE_COLOR_PALETTE[colorKey] ?? TIMELINE_COLOR_PALETTE[DEFAULT_TIMELINE_COLOR_KEY];
+}
+
+export function GanttLane({ id, data, selected }: NodeProps) {
+  const d = (data as unknown) as TimelineBlockData;
   const blocks = d.blocks ?? [];
+  const activeBlockIndex = d.activeBlockIndex ?? null;
+  const axisMax = Math.max(1, ...blocks.map(b => b.end), 1);
   const totalW = axisMax * SCALE;
-  const color = DEFAULT_COLOR;
+  const trackColor = TIMELINE_COLOR_PALETTE[DEFAULT_TIMELINE_COLOR_KEY];
+  const { checkpointStatus } = useFrameCtx();
+  const status = checkpointStatus?.[id] ?? null;
 
-  // Unique tick values from block boundaries
   const ticks = [...new Set([0, ...blocks.flatMap(b => [b.start, b.end]), axisMax])].sort((a, b) => a - b);
 
   return (
-    <div style={{
-      display: 'inline-flex', flexDirection: 'column', gap: 0,
-      boxShadow: selected ? `0 0 0 3px ${color}40` : undefined,
-      cursor: 'grab', userSelect: 'none',
-    }}>
-      <Handle id="t" type="source" position={Position.Top}    style={{ background: color, border: 'none' }} />
-      <Handle id="b" type="source" position={Position.Bottom} style={{ background: color, border: 'none' }} />
-      {d.label && (
-        <div style={{ fontSize: 10, fontWeight: 600, color: '#64748b', marginBottom: 3 }}>{d.label}</div>
-      )}
-      {/* Timeline track */}
-      <div style={{ position: 'relative', width: totalW, height: 36, backgroundColor: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: 4 }}>
-        {blocks.map((b, i) => (
-          <div key={i} style={{
-            position: 'absolute',
-            left: b.start * SCALE,
-            width: (b.end - b.start) * SCALE,
-            height: '100%',
-            backgroundColor: (b.color ?? DEFAULT_COLOR) + '30',
-            border: `1.5px solid ${b.color ?? DEFAULT_COLOR}`,
-            borderRadius: 2,
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            overflow: 'hidden',
-          }}>
-            <span style={{ fontSize: 11, fontWeight: 700, color: b.color ?? DEFAULT_COLOR }}>{b.label}</span>
-          </div>
-        ))}
-      </div>
-      {/* Axis */}
-      <div style={{ position: 'relative', width: totalW, height: 14 }}>
-        {ticks.map(t => (
-          <span key={t} style={{
-            position: 'absolute', left: t * SCALE - 4,
-            fontSize: 8, color: '#94a3b8',
-          }}>{t}</span>
-        ))}
-      </div>
-    </div>
-  );
-}
+    <CheckpointStatusRing status={status}>
+      <div style={{
+        display: 'inline-flex', alignItems: 'center', gap: 10,
+        cursor: 'grab', userSelect: 'none', position: 'relative',
+      }}>
+        <Handle id="t" type="source" position={Position.Top}    style={{ background: trackColor, border: 'none' }} />
+        <Handle id="b" type="source" position={Position.Bottom} style={{ background: trackColor, border: 'none' }} />
 
-function StepMode({ d, selected }: { d: GanttLaneData; selected: boolean }) {
-  const blocks = d.blocks ?? [];
-  return (
-    <div style={{
-      display: 'inline-flex', alignItems: 'center',
-      boxShadow: selected ? '0 0 0 3px #33415540' : undefined,
-      cursor: 'grab', userSelect: 'none',
-    }}>
-      <Handle id="l" type="source" position={Position.Left}  style={{ background: '#94a3b8', border: 'none' }} />
-      <Handle id="r" type="source" position={Position.Right} style={{ background: '#94a3b8', border: 'none' }} />
-      {blocks.map((b, i) => (
-        <div key={i} style={{ display: 'flex', alignItems: 'center' }}>
+        {d.trackId && (
           <div style={{
-            padding: '6px 10px',
-            border: `1.5px solid ${b.color ?? '#6366f1'}`,
-            borderRadius: 4, backgroundColor: 'white',
-            fontSize: 11, fontWeight: 600, color: b.color ?? '#6366f1',
-            whiteSpace: 'nowrap' as const,
+            fontSize: 11, fontWeight: 800, color: '#475569',
+            background: '#f1f5f9', borderRadius: 8, padding: '5px 9px',
+            minWidth: 28, textAlign: 'center', flexShrink: 0,
           }}>
-            {b.label}
+            {d.trackId}
           </div>
-          {i < blocks.length - 1 && (
-            <div style={{ width: 20, textAlign: 'center', color: '#94a3b8', fontSize: 12, flexShrink: 0 }}>→</div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-}
+        )}
 
-export function GanttLane({ data, selected }: NodeProps) {
-  const d = (data as unknown) as GanttLaneData;
-  return d.mode === 'step'
-    ? <StepMode d={d} selected={selected ?? false} />
-    : <BlockMode d={d} selected={selected ?? false} />;
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <div style={{
+            position: 'relative', width: totalW, height: TRACK_H,
+            backgroundColor: '#f8fafc', border: '1px solid #e2e8f0', borderRadius: 8,
+            boxShadow: selected ? `0 0 0 3px ${trackColor}40` : undefined,
+          }}>
+            {blocks.map((b, i) => {
+              const color = colorFor(b.colorKey);
+              const isActive = i === activeBlockIndex;
+              return (
+                <div key={i} style={{
+                  position: 'absolute', top: 3, bottom: 3,
+                  left: b.start * SCALE + (b.start === 0 ? 0 : 1),
+                  width: (b.end - b.start) * SCALE - (b.start === 0 ? 1 : 2),
+                }}>
+                  {isActive && (
+                    <div
+                      className="absolute -inset-1.5 rounded-lg opacity-70 animate-pulse pointer-events-none"
+                      style={{ boxShadow: `0 0 0 2.5px ${color}` }}
+                    />
+                  )}
+                  <div style={{
+                    position: 'absolute', inset: 0,
+                    backgroundColor: color,
+                    borderRadius: 5,
+                    boxShadow: isActive ? `0 2px 6px ${color}80` : '0 1px 2px rgba(15,23,42,0.12)',
+                  }} />
+                </div>
+              );
+            })}
+          </div>
+          <div style={{ position: 'relative', width: totalW, height: 12 }}>
+            {ticks.map(t => (
+              <span key={t} style={{
+                position: 'absolute', left: t * SCALE - 4,
+                fontSize: 9, color: '#94a3b8', fontWeight: 600,
+              }}>{t}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </CheckpointStatusRing>
+  );
 }

--- a/components/obo/nodes/SlotGrid.tsx
+++ b/components/obo/nodes/SlotGrid.tsx
@@ -1,145 +1,92 @@
 'use client';
 
 import { Handle, Position, type NodeProps } from '@xyflow/react';
-
-export interface SlotCell {
-  value?: string;
-  status?: 'default' | 'fault' | 'hit' | 'empty';
-}
+import { useFrameCtx } from '../FrameContext';
+import { CheckpointStatusRing } from './CheckpointStatusRing';
 
 interface SlotGridData {
-  label?: string;
-  title?: string;
-  orientation?: 'row' | 'col' | 'grid';
-  rows?: number;
-  cols?: number;
-  cellShape?: 'rect' | 'circle';
-  header?: boolean;
-  headerLabels?: string[];
-  cells?: SlotCell[];
-  trailingArrow?: boolean;
+  slotCount?: number;
+  slots?: (number | null)[];
+  faultSlotIndex?: number | null;
+  hitSlotIndex?: number | null;
 }
 
 const FAULT_COLOR = '#E24B4A';
 const HIT_COLOR = '#1D9E75';
-const GRID_COLOR = '#6366f1';
-const CELL_W = 32;
-const CELL_H = 32;
+const IDLE_COLOR = '#6366f1';
+const CELL_W = 40;
+const CELL_H = 40;
 
-function CircleCell({ cell }: { cell: SlotCell }) {
-  const s = cell.status ?? 'default';
-  const isFault = s === 'fault';
-  const isHit = s === 'hit';
-  return (
-    <div style={{
-      width: 14, height: 14, borderRadius: '50%', flexShrink: 0,
-      backgroundColor: isFault ? FAULT_COLOR : 'white',
-      border: `2px solid ${isFault ? FAULT_COLOR : isHit ? HIT_COLOR : '#cbd5e1'}`,
-    }} />
-  );
-}
-
-function RectCell({ cell, i, borderColor }: { cell: SlotCell; i: number; borderColor: string }) {
-  const s = cell.status ?? 'default';
-  const isFault = s === 'fault';
-  const isHit = s === 'hit';
-  return (
-    <div style={{
-      width: CELL_W, height: CELL_H,
-      border: `1.5px solid ${borderColor}`,
-      marginLeft: i === 0 ? 0 : -1,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      fontSize: 11, fontWeight: isFault ? 700 : 500,
-      color: isFault ? FAULT_COLOR : isHit ? HIT_COLOR : borderColor,
-      backgroundColor: isFault ? FAULT_COLOR + '15' : isHit ? HIT_COLOR + '10' : 'white',
-    }}>
-      {cell.value ?? ''}
-    </div>
-  );
-}
-
-export function SlotGrid({ data, selected }: NodeProps) {
+export function SlotGrid({ id, data, selected }: NodeProps) {
   const d = (data as unknown) as SlotGridData;
-  const orientation = d.orientation ?? 'row';
-  const cellShape = d.cellShape ?? 'rect';
-  const cells = d.cells ?? [];
-  const cols = d.cols ?? 4;
-  const rows = d.rows ?? Math.max(1, Math.ceil(cells.length / cols));
-  const hs = { background: GRID_COLOR, border: 'none' };
+  const slotCount = d.slotCount ?? (d.slots?.length ?? 0);
+  const slots = d.slots ?? [];
+  const faultSlotIndex = d.faultSlotIndex ?? null;
+  const hitSlotIndex = d.hitSlotIndex ?? null;
+  const hs = { background: IDLE_COLOR, border: 'none' };
+  const { checkpointStatus } = useFrameCtx();
+  const status = checkpointStatus?.[id] ?? null;
 
   return (
-    <div style={{
-      display: 'inline-flex', flexDirection: 'column', gap: 2,
-      boxShadow: selected ? `0 0 0 3px ${GRID_COLOR}40` : undefined,
-      cursor: 'grab', userSelect: 'none',
-    }}>
-      <Handle id="t" type="source" position={Position.Top}    style={hs} />
-      <Handle id="b" type="source" position={Position.Bottom} style={hs} />
-      <Handle id="l" type="source" position={Position.Left}   style={hs} />
-      <Handle id="r" type="source" position={Position.Right}  style={hs} />
+    <CheckpointStatusRing status={status}>
+      <div style={{
+        display: 'inline-flex', flexDirection: 'column', alignItems: 'center', gap: 2,
+        cursor: 'grab', userSelect: 'none', position: 'relative',
+      }}>
+        <Handle id="t" type="source" position={Position.Top}    style={hs} />
+        <Handle id="b" type="source" position={Position.Bottom} style={hs} />
+        <Handle id="l" type="source" position={Position.Left}   style={hs} />
+        <Handle id="r" type="source" position={Position.Right}  style={hs} />
 
-      {d.title && (
-        <div style={{ fontSize: 10, fontWeight: 600, color: '#64748b', marginBottom: 2 }}>{d.title}</div>
-      )}
-
-      {orientation === 'grid' ? (
-        <table style={{ borderCollapse: 'collapse', fontSize: 11 }}>
-          {d.header && d.headerLabels && (
-            <thead>
-              <tr>
-                {d.headerLabels.map((h, i) => (
-                  <th key={i} style={{
-                    padding: '2px 8px', border: '1px solid #e2e8f0',
-                    backgroundColor: GRID_COLOR + '15', color: GRID_COLOR,
-                    fontWeight: 700, fontSize: 10, whiteSpace: 'nowrap' as const,
+        <div style={{
+          display: 'flex', alignItems: 'center',
+          borderRadius: 10, overflow: 'hidden',
+          boxShadow: selected ? `0 0 0 3px ${IDLE_COLOR}40` : '0 1px 4px rgba(15,23,42,0.06)',
+        }}>
+          {Array.from({ length: slotCount }).map((_, i) => {
+            const value = slots[i] ?? null;
+            const isFault = i === faultSlotIndex;
+            const isHit = i === hitSlotIndex;
+            const active = isFault || isHit;
+            const accent = isFault ? FAULT_COLOR : isHit ? HIT_COLOR : '#cbd5e1';
+            return (
+              <div key={i} style={{ position: 'relative', width: CELL_W, height: CELL_H }}>
+                {active && (
+                  <span style={{
+                    position: 'absolute', top: -20, left: '50%', transform: 'translateX(-50%)',
+                    fontSize: 9, fontWeight: 800, letterSpacing: 0.3,
+                    color: 'white', background: accent,
+                    borderRadius: 999, padding: '1.5px 6px', whiteSpace: 'nowrap',
                   }}>
-                    {h}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-          )}
-          <tbody>
-            {Array.from({ length: rows }).map((_, r) => (
-              <tr key={r}>
-                {Array.from({ length: cols }).map((__, c) => {
-                  const cell = cells[r * cols + c] ?? {};
-                  const s = cell.status ?? 'default';
-                  return (
-                    <td key={c} style={{
-                      padding: '2px 8px', border: '1px solid #e2e8f0',
-                      fontSize: 11, color: s === 'fault' ? FAULT_COLOR : s === 'hit' ? HIT_COLOR : '#374151',
-                      textAlign: 'center' as const,
-                      backgroundColor: s === 'fault' ? FAULT_COLOR + '10' : 'white',
-                    }}>
-                      {cell.value ?? ''}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      ) : orientation === 'col' ? (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: cellShape === 'circle' ? 4 : 0 }}>
-          {cells.map((cell, i) =>
-            cellShape === 'circle'
-              ? <CircleCell key={i} cell={cell} />
-              : <RectCell key={i} cell={cell} i={i} borderColor={GRID_COLOR} />
-          )}
+                    {isFault ? 'FAULT' : 'HIT'}
+                  </span>
+                )}
+                <div style={{
+                  width: CELL_W, height: CELL_H,
+                  borderLeft: i === 0 ? `2px solid ${accent}` : `1px solid ${accent}`,
+                  borderTop: `2px solid ${accent}`, borderBottom: `2px solid ${accent}`,
+                  borderRight: i === slotCount - 1 ? `2px solid ${accent}` : 'none',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 13, fontWeight: active ? 800 : 600,
+                  color: isFault ? FAULT_COLOR : isHit ? HIT_COLOR : '#334155',
+                  backgroundColor: isFault ? FAULT_COLOR + '18' : isHit ? HIT_COLOR + '14' : 'white',
+                  transition: 'background-color 200ms, border-color 200ms',
+                }}>
+                  {value ?? '·'}
+                </div>
+              </div>
+            );
+          })}
         </div>
-      ) : (
-        <div style={{ display: 'flex', alignItems: 'center', gap: cellShape === 'circle' ? 4 : 0 }}>
-          {cells.map((cell, i) =>
-            cellShape === 'circle'
-              ? <CircleCell key={i} cell={cell} />
-              : <RectCell key={i} cell={cell} i={i} borderColor={GRID_COLOR} />
-          )}
-          {d.trailingArrow && (
-            <div style={{ marginLeft: 6, fontSize: 14, color: '#64748b' }}>→</div>
-          )}
+
+        <div style={{ display: 'flex' }}>
+          {Array.from({ length: slotCount }).map((_, i) => (
+            <div key={i} style={{ width: CELL_W, textAlign: 'center', fontSize: 9, color: '#94a3b8', fontWeight: 600 }}>
+              {i}
+            </div>
+          ))}
         </div>
-      )}
-    </div>
+      </div>
+    </CheckpointStatusRing>
   );
 }

--- a/components/obo/nodes/StateNode.tsx
+++ b/components/obo/nodes/StateNode.tsx
@@ -2,6 +2,7 @@
 
 import { Handle, Position, type NodeProps } from '@xyflow/react';
 import { useFrameCtx } from '../FrameContext';
+import { CheckpointStatusRing } from './CheckpointStatusRing';
 
 interface StateNodeData {
   label: string;
@@ -20,10 +21,11 @@ export function StateNode({ id, data, selected }: NodeProps) {
   const isHighlit = d.highlight ?? false;
   const hs = { ...HS, background: color };
 
-  const { previewFrame } = useFrameCtx();
+  const { previewFrame, checkpointStatus } = useFrameCtx();
   const frameHighlighted = previewFrame?.highlightNodes.includes(id) ?? false;
   const frameDimmed = previewFrame !== null && !frameHighlighted;
   const active = isHighlit || frameHighlighted;
+  const status = checkpointStatus?.[id] ?? null;
 
   const handles = (
     <>
@@ -48,46 +50,50 @@ export function StateNode({ id, data, selected }: NodeProps) {
 
   if (d.shape !== 'box') {
     return (
-      <div style={{ position: 'relative', width: 80, height: 80 }}>
-        {frameHighlighted && (
-          <div
-            className="absolute inset-0 -m-3 rounded-full border-2 border-dashed animate-[spin_6s_linear_infinite] opacity-50 pointer-events-none"
-            style={{ borderColor: color, transformOrigin: '50% 50%' }}
-          />
-        )}
-        <div style={{
-          width: 80, height: 80, borderRadius: '50%',
-          border: `2.5px solid ${active ? color : IDLE_BORDER}`,
-          backgroundColor: active ? color : 'white',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow, opacity,
-          userSelect: 'none', cursor: 'grab',
-          transition: 'background-color 300ms, border-color 300ms, box-shadow 300ms',
-        }}>
-          {handles}
-          <span style={{
-            ...labelStyle,
-            maxWidth: 64, padding: '0 8px',
-          }}>{d.label}</span>
+      <CheckpointStatusRing status={status}>
+        <div style={{ position: 'relative', width: 80, height: 80 }}>
+          {frameHighlighted && (
+            <div
+              className="absolute inset-0 -m-3 rounded-full border-2 border-dashed animate-[spin_6s_linear_infinite] opacity-50 pointer-events-none"
+              style={{ borderColor: color, transformOrigin: '50% 50%' }}
+            />
+          )}
+          <div style={{
+            width: 80, height: 80, borderRadius: '50%',
+            border: `2.5px solid ${active ? color : IDLE_BORDER}`,
+            backgroundColor: active ? color : 'white',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            boxShadow, opacity,
+            userSelect: 'none', cursor: 'grab',
+            transition: 'background-color 300ms, border-color 300ms, box-shadow 300ms',
+          }}>
+            {handles}
+            <span style={{
+              ...labelStyle,
+              maxWidth: 64, padding: '0 8px',
+            }}>{d.label}</span>
+          </div>
         </div>
-      </div>
+      </CheckpointStatusRing>
     );
   }
 
   return (
-    <div style={{
-      padding: '8px 16px', borderRadius: 8, minWidth: 80,
-      border: `2px solid ${active ? color : IDLE_BORDER}`,
-      backgroundColor: active ? color : 'white',
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      boxShadow, opacity,
-      userSelect: 'none', cursor: 'grab',
-      transition: 'background-color 300ms, border-color 300ms, box-shadow 300ms',
-    }}>
-      {handles}
-      <span style={{
-        ...labelStyle, fontSize: 13, whiteSpace: 'nowrap',
-      }}>{d.label}</span>
-    </div>
+    <CheckpointStatusRing status={status}>
+      <div style={{
+        padding: '8px 16px', borderRadius: 8, minWidth: 80,
+        border: `2px solid ${active ? color : IDLE_BORDER}`,
+        backgroundColor: active ? color : 'white',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        boxShadow, opacity,
+        userSelect: 'none', cursor: 'grab',
+        transition: 'background-color 300ms, border-color 300ms, box-shadow 300ms',
+      }}>
+        {handles}
+        <span style={{
+          ...labelStyle, fontSize: 13, whiteSpace: 'nowrap',
+        }}>{d.label}</span>
+      </div>
+    </CheckpointStatusRing>
   );
 }

--- a/components/obo/nodes/TextLabel.tsx
+++ b/components/obo/nodes/TextLabel.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { useFrameCtx } from '../FrameContext';
+import { CheckpointStatusRing } from './CheckpointStatusRing';
 
 interface TextLabelData {
   label?: string; // for compat
@@ -9,11 +11,13 @@ interface TextLabelData {
   color?: string;
 }
 
-export function TextLabel({ data, selected }: NodeProps) {
+export function TextLabel({ id, data, selected }: NodeProps) {
   const d = (data as unknown) as TextLabelData;
   const text = d.text ?? d.label ?? '';
   const color = d.color ?? '#334155';
   const variant = d.variant ?? 'plain';
+  const { checkpointStatus } = useFrameCtx();
+  const status = checkpointStatus?.[id] ?? null;
 
   const border =
     variant === 'dashed-box' ? `1.5px dashed ${color}` :
@@ -27,16 +31,18 @@ export function TextLabel({ data, selected }: NodeProps) {
   const padding = variant === 'plain' ? '2px 4px' : '4px 12px';
 
   return (
-    <div style={{
-      padding, borderRadius, border,
-      backgroundColor: 'white',
-      boxShadow: selected ? `0 0 0 3px ${color}40` : undefined,
-      cursor: 'grab', userSelect: 'none',
-      display: 'inline-flex', alignItems: 'center',
-    }}>
-      <Handle id="l" type="source" position={Position.Left}  style={{ background: color, border: 'none' }} />
-      <Handle id="r" type="source" position={Position.Right} style={{ background: color, border: 'none' }} />
-      <span style={{ fontSize: 12, fontWeight: 600, color, whiteSpace: 'nowrap' as const }}>{text}</span>
-    </div>
+    <CheckpointStatusRing status={status}>
+      <div style={{
+        padding, borderRadius, border,
+        backgroundColor: 'white',
+        boxShadow: selected ? `0 0 0 3px ${color}40` : undefined,
+        cursor: 'grab', userSelect: 'none',
+        display: 'inline-flex', alignItems: 'center',
+      }}>
+        <Handle id="l" type="source" position={Position.Left}  style={{ background: color, border: 'none' }} />
+        <Handle id="r" type="source" position={Position.Right} style={{ background: color, border: 'none' }} />
+        <span style={{ fontSize: 12, fontWeight: 600, color, whiteSpace: 'nowrap' as const }}>{text}</span>
+      </div>
+    </CheckpointStatusRing>
   );
 }

--- a/components/obo/nodes/defaultNodeData.ts
+++ b/components/obo/nodes/defaultNodeData.ts
@@ -6,15 +6,14 @@ export const DEFAULT_NODE_DATA: Record<string, object> = {
     label: 'R1', instances: 2, allocated: 1,
   },
   'slot-grid': {
-    title: 'Frame', orientation: 'row', cols: 4,
-    cells: [{ value: '' }, { value: '' }, { value: '' }, { value: '' }],
+    slotCount: 4, slots: [null, null, null, null],
+    faultSlotIndex: null, hitSlotIndex: null,
   },
   'gantt-lane': {
-    label: '', mode: 'block', axisMax: 8,
-    blocks: [
-      { label: 'P1', start: 0, end: 3, color: '#1D9E75' },
-      { label: 'P2', start: 3, end: 7, color: '#6366f1' },
-    ],
+    trackId: 'P1', blocks: [], activeBlockIndex: null,
+  },
+  'counter-badge': {
+    label: 'Counter', min: 0, max: 10, value: 0, delta: null,
   },
   'line-chart': {
     label: 'Chart', xLabel: '프레임 수', yLabel: '페이지 폴트',

--- a/components/obo/nodes/ganttColors.ts
+++ b/components/obo/nodes/ganttColors.ts
@@ -1,0 +1,12 @@
+export const TIMELINE_COLOR_PALETTE: Record<string, string> = {
+  teal: '#0d9488',
+  indigo: '#6366f1',
+  amber: '#d97706',
+  rose: '#e11d48',
+  slate: '#64748b',
+  violet: '#7c3aed',
+};
+
+export const TIMELINE_COLOR_KEYS = Object.keys(TIMELINE_COLOR_PALETTE);
+
+export const DEFAULT_TIMELINE_COLOR_KEY = 'teal';

--- a/components/obo/nodes/index.ts
+++ b/components/obo/nodes/index.ts
@@ -1,9 +1,10 @@
-import { StateNode }       from './StateNode';
-import { ResourceSquare }  from './ResourceSquare';
-import { SlotGrid }        from './SlotGrid';
-import { GanttLane }       from './GanttLane';
-import { LineChart }       from './LineChart';
-import { TextLabel }       from './TextLabel';
+import { StateNode }        from './StateNode';
+import { ResourceSquare }   from './ResourceSquare';
+import { SlotGrid }         from './SlotGrid';
+import { GanttLane }        from './GanttLane';
+import { LineChart }        from './LineChart';
+import { TextLabel }        from './TextLabel';
+import { CounterBadgeNode } from './CounterBadgeNode';
 
 // 컴포넌트 외부(모듈 레벨)에서 정의해야 React Flow가 노드를 리마운트하지 않음
 export const nodeTypes = {
@@ -13,4 +14,5 @@ export const nodeTypes = {
   'gantt-lane':      GanttLane,
   'line-chart':      LineChart,
   'text-label':      TextLabel,
+  'counter-badge':   CounterBadgeNode,
 } as const;

--- a/components/obo/panel/EdgeProps.tsx
+++ b/components/obo/panel/EdgeProps.tsx
@@ -10,7 +10,7 @@ interface OboEdgeData {
   direction?: 'forward' | 'both';
   style?: 'solid' | 'dashed';
   role?: 'transition' | 'request' | 'allocation';
-  highlight?: boolean;
+  emphasize?: boolean;
 }
 
 interface EdgeEditorProps {
@@ -46,7 +46,7 @@ export function EdgeEditor({ edge, onUpdate }: EdgeEditorProps) {
         ]}
         onChange={v => onUpdate({ role: v as OboEdgeData['role'] })}
       />
-      <ToggleField label="강조" value={d.highlight ?? false} onChange={v => onUpdate({ highlight: v })} />
+      <ToggleField label="강조" value={d.emphasize ?? false} onChange={v => onUpdate({ emphasize: v })} />
     </div>
   );
 }

--- a/components/obo/panel/FramePanel.tsx
+++ b/components/obo/panel/FramePanel.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import { useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import type { Node, Edge } from '@xyflow/react';
 import type { Frame } from '../types';
+import { OVERRIDABLE_NODE_TYPES } from '../lib/overrideFields';
+import { NodeOverrideEditor } from './overrides/NodeOverrideEditor';
 
 interface FramePanelProps {
   frames: Frame[];
@@ -13,6 +16,11 @@ interface FramePanelProps {
   onUpdateLabel: (id: string, label: string) => void;
   onRemoveHighlightNode: (frameId: string, nodeId: string) => void;
   onRemoveHighlightEdge: (frameId: string, edgeId: string) => void;
+  onAddNodeOverride: (frameId: string, nodeId: string) => void;
+  onRemoveNodeOverride: (frameId: string, nodeId: string) => void;
+  onSetOverrideField: (frameId: string, nodeId: string, field: string, value: unknown) => void;
+  onClearOverrideField: (frameId: string, nodeId: string, field: string) => void;
+  onUpdateFrameCursorTime: (frameId: string, cursorTime: number | undefined) => void;
   nodes: Node[];
   edges: Edge[];
 }
@@ -32,9 +40,12 @@ export function FramePanel({
   frames, selectedFrameId,
   onSelectFrame, onAddFrame, onRemoveFrame, onUpdateLabel,
   onRemoveHighlightNode, onRemoveHighlightEdge,
+  onAddNodeOverride, onRemoveNodeOverride, onSetOverrideField, onClearOverrideField, onUpdateFrameCursorTime,
   nodes, edges,
 }: FramePanelProps) {
   const selectedFrame = frames.find(f => f.id === selectedFrameId) ?? null;
+  const selectedFrameIndex = selectedFrame ? frames.findIndex(f => f.id === selectedFrame.id) : -1;
+  const [pickerNodeId, setPickerNodeId] = useState('');
 
   return (
     <div className="p-3 space-y-3">
@@ -139,6 +150,91 @@ export function FramePanel({
           <p className="text-[10px] text-slate-400 bg-slate-50 rounded px-2 py-1.5 leading-relaxed">
             캔버스에서 노드/엣지를 클릭하면 이 프레임에 추가됩니다
           </p>
+
+          {/* 오버라이드 */}
+          <div className="border-t pt-3 space-y-2">
+            <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">오버라이드</label>
+            {(() => {
+              const overrides = selectedFrame.nodeDataOverrides ?? {};
+              const overriddenIds = Object.keys(overrides);
+              const candidates = nodes.filter(n =>
+                n.type && OVERRIDABLE_NODE_TYPES.includes(n.type) && !overriddenIds.includes(n.id)
+              );
+              return (
+                <>
+                  {candidates.length > 0 && (
+                    <div className="flex items-center gap-1.5">
+                      <select
+                        value={pickerNodeId}
+                        onChange={e => setPickerNodeId(e.target.value)}
+                        className="flex-1 text-xs border border-slate-200 rounded px-2 py-1 bg-white"
+                      >
+                        <option value="">노드 선택...</option>
+                        {candidates.map(n => (
+                          <option key={n.id} value={n.id}>{nodeLabel(nodes, n.id)}</option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={() => {
+                          if (!pickerNodeId) return;
+                          onAddNodeOverride(selectedFrame.id, pickerNodeId);
+                          setPickerNodeId('');
+                        }}
+                        disabled={!pickerNodeId}
+                        className="shrink-0 px-2 py-1 text-xs rounded border border-indigo-200 text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+                      >
+                        추가
+                      </button>
+                    </div>
+                  )}
+
+                  {overriddenIds.length === 0 ? (
+                    <p className="text-[10px] text-slate-400 italic">오버라이드된 노드가 없습니다</p>
+                  ) : (
+                    <div className="space-y-3">
+                      {overriddenIds.map(nodeId => {
+                        const node = nodes.find(n => n.id === nodeId);
+                        if (!node) return null;
+                        return (
+                          <div key={nodeId} className="border border-slate-100 rounded-lg p-2 space-y-2">
+                            <div className="flex items-center justify-between">
+                              <span className="text-[11px] font-bold text-slate-600 truncate">{nodeLabel(nodes, nodeId)}</span>
+                              <button
+                                onClick={() => onRemoveNodeOverride(selectedFrame.id, nodeId)}
+                                className="text-slate-300 hover:text-red-400 transition-colors shrink-0"
+                              >
+                                <X size={11} />
+                              </button>
+                            </div>
+                            <NodeOverrideEditor
+                              node={node}
+                              frames={frames}
+                              frameIndex={selectedFrameIndex}
+                              override={overrides[nodeId] ?? {}}
+                              onFieldChange={(field, value) => onSetOverrideField(selectedFrame.id, nodeId, field, value)}
+                              onFieldClear={field => onClearOverrideField(selectedFrame.id, nodeId, field)}
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </>
+              );
+            })()}
+          </div>
+
+          {/* cursorTime */}
+          <div className="space-y-1">
+            <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">커서 시간 (선택)</label>
+            <input
+              type="number"
+              value={selectedFrame.cursorTime ?? ''}
+              onChange={e => onUpdateFrameCursorTime(selectedFrame.id, e.target.value === '' ? undefined : Number(e.target.value))}
+              placeholder="-"
+              className="w-full text-xs border border-slate-200 rounded px-2 py-1 outline-none focus:border-indigo-400 transition-colors"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/components/obo/panel/NodeProps.tsx
+++ b/components/obo/panel/NodeProps.tsx
@@ -6,7 +6,7 @@ import { NumField } from './fields/Num';
 import { ColorField } from './fields/Color';
 import { SegField } from './fields/Seg';
 import { ToggleField } from './fields/Toggle';
-import { ListEditor, type SlotCell, type GanttBlock, type ChartSeries } from './fields/ListEditor';
+import { ListEditor, type GanttBlock, type ChartSeries } from './fields/ListEditor';
 
 function Divider() {
   return <div className="h-px bg-slate-100" />;
@@ -56,57 +56,66 @@ export function NodeEditor({ node, onUpdate }: NodeEditorProps) {
   }
 
   if (node.type === 'slot-grid') {
-    const cells = (d.cells as SlotCell[]) ?? [];
-    const header = (d.header as boolean) ?? false;
+    const slotCount = (d.slotCount as number) ?? 0;
+    const slots = (d.slots as (number | null)[]) ?? [];
+    const resize = (count: number) => {
+      const next = Array.from({ length: count }, (_, i) => slots[i] ?? null);
+      onUpdate({ slotCount: count, slots: next });
+    };
+    const updateSlot = (i: number, raw: string) => {
+      const next = [...slots];
+      next[i] = raw === '' ? null : Number(raw);
+      onUpdate({ slots: next });
+    };
     return (
-      <div className="space-y-4">
-        <Section>
-          <TextField label="제목" value={(d.title as string) ?? ''} onChange={v => onUpdate({ title: v })} />
-          <SegField label="방향" value={(d.orientation as string) ?? 'row'}
-            options={[{ value: 'row', label: '행' }, { value: 'col', label: '열' }, { value: 'grid', label: '격자' }]}
-            onChange={v => onUpdate({ orientation: v })} />
-          <NumField label="열 수" value={(d.cols as number) ?? 4} min={1} max={8}
-            onChange={v => onUpdate({ cols: v })} />
-          <SegField label="셀 모양" value={(d.cellShape as string) ?? 'rect'}
-            options={[{ value: 'rect', label: '사각' }, { value: 'circle', label: '원형' }]}
-            onChange={v => onUpdate({ cellShape: v })} />
-          <ToggleField label="헤더" value={header} onChange={v => onUpdate({ header: v })} />
-          {header && (
-            <TextField label="헤더 라벨" placeholder="P0, P1, P2"
-              value={((d.headerLabels as string[]) ?? []).join(', ')}
-              onChange={v => onUpdate({ headerLabels: v.split(',').map(s => s.trim()).filter(Boolean) })} />
-          )}
-          <ToggleField label="꼬리 화살표" value={(d.trailingArrow as boolean) ?? false}
-            onChange={v => onUpdate({ trailingArrow: v })} />
-        </Section>
-        <Divider />
-        <Section title="셀 목록">
-          <ListEditor mode="cells" value={cells} onChange={newCells => onUpdate({ cells: newCells })} />
-        </Section>
-      </div>
+      <Section>
+        <NumField label="슬롯 개수" value={slotCount} min={1} max={16} onChange={resize} />
+        <div className="space-y-1">
+          <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">초기 슬롯 값</label>
+          <div className="flex flex-wrap gap-1.5">
+            {Array.from({ length: slotCount }).map((_, i) => (
+              <input
+                key={i}
+                value={slots[i] ?? ''}
+                onChange={e => updateSlot(i, e.target.value)}
+                placeholder="-"
+                className="w-10 px-1 py-1 text-xs text-center border border-slate-200 rounded bg-white focus:outline-none focus:ring-1 focus:ring-indigo-300"
+              />
+            ))}
+          </div>
+        </div>
+      </Section>
     );
   }
 
   if (node.type === 'gantt-lane') {
-    const mode = (d.mode as string) ?? 'block';
     const blocks = (d.blocks as GanttBlock[]) ?? [];
     return (
       <div className="space-y-4">
         <Section>
-          <TextField label="라벨" value={(d.label as string) ?? ''} onChange={v => onUpdate({ label: v })} />
-          <SegField label="모드" value={mode}
-            options={[{ value: 'block', label: '블록' }, { value: 'step', label: '스텝' }]}
-            onChange={v => onUpdate({ mode: v })} />
-          {mode === 'block' && (
-            <NumField label="축 최대값" value={(d.axisMax as number) ?? 8} min={1} max={30}
-              onChange={v => onUpdate({ axisMax: v })} />
-          )}
+          <TextField label="트랙 ID" value={(d.trackId as string) ?? ''} onChange={v => onUpdate({ trackId: v })} />
         </Section>
         <Divider />
         <Section title="블록 목록">
           <ListEditor mode="blocks" value={blocks} onChange={newBlocks => onUpdate({ blocks: newBlocks })} />
         </Section>
       </div>
+    );
+  }
+
+  if (node.type === 'counter-badge') {
+    const min = (d.min as number) ?? 0;
+    const max = (d.max as number) ?? 10;
+    return (
+      <Section>
+        <TextField label="라벨" value={(d.label as string) ?? ''} onChange={v => onUpdate({ label: v })} />
+        <NumField label="최솟값" value={min} min={-999} max={max}
+          onChange={v => onUpdate({ min: v })} />
+        <NumField label="최댓값" value={max} min={min} max={999}
+          onChange={v => onUpdate({ max: v })} />
+        <NumField label="초기값" value={(d.value as number) ?? min} min={min} max={max}
+          onChange={v => onUpdate({ value: v })} />
+      </Section>
     );
   }
 

--- a/components/obo/panel/PropertyPanel.tsx
+++ b/components/obo/panel/PropertyPanel.tsx
@@ -3,11 +3,12 @@
 import { Trash2 } from 'lucide-react';
 import type { Node, Edge } from '@xyflow/react';
 import type { EdgeType } from '../templates';
-import type { Frame } from '../types';
+import type { Frame, OboMode } from '../types';
 import { NodeEditor } from './NodeProps';
 import { EdgeEditor } from './EdgeProps';
 import { Palette } from './Palette';
 import { FramePanel } from './FramePanel';
+import { TracePanel } from './TracePanel';
 
 type PanelMode = 'palette' | 'property' | 'json';
 
@@ -30,6 +31,7 @@ interface PropertyPanelProps {
   onJsonClose: () => void;
   onDelete: () => void;
   // 프레임 탭
+  oboMode: OboMode;
   frames: Frame[];
   selectedFrameId: string | null;
   onSelectFrame: (id: string) => void;
@@ -38,6 +40,15 @@ interface PropertyPanelProps {
   onUpdateFrameLabel: (id: string, label: string) => void;
   onRemoveHighlightNode: (frameId: string, nodeId: string) => void;
   onRemoveHighlightEdge: (frameId: string, edgeId: string) => void;
+  onAddNodeOverride: (frameId: string, nodeId: string) => void;
+  onRemoveNodeOverride: (frameId: string, nodeId: string) => void;
+  onSetOverrideField: (frameId: string, nodeId: string, field: string, value: unknown) => void;
+  onClearOverrideField: (frameId: string, nodeId: string, field: string) => void;
+  onUpdateFrameCursorTime: (frameId: string, cursorTime: number | undefined) => void;
+  // coding_diff 전용 (frames 대신 트레이스 텍스트로 프레임 자동 생성)
+  traceText: string;
+  onTraceTextChange: (text: string) => void;
+  testcaseOutputs?: { index: number; output: string }[];
 }
 
 export function PropertyPanel({
@@ -46,8 +57,10 @@ export function PropertyPanel({
   updateNodeData, updateEdgeData,
   activeEdgeType, onEdgeTypeChange,
   currentNodes, currentEdges, onJsonClose, onDelete,
-  frames, selectedFrameId, onSelectFrame, onAddFrame, onRemoveFrame,
+  oboMode, frames, selectedFrameId, onSelectFrame, onAddFrame, onRemoveFrame,
   onUpdateFrameLabel, onRemoveHighlightNode, onRemoveHighlightEdge,
+  onAddNodeOverride, onRemoveNodeOverride, onSetOverrideField, onClearOverrideField, onUpdateFrameCursorTime,
+  traceText, onTraceTextChange, testcaseOutputs,
 }: PropertyPanelProps) {
   const selectedNode = selectedKind === 'node' ? nodes.find(n => n.id === selectedId) ?? null : null;
   const selectedEdge = selectedKind === 'edge' ? edges.find(e => e.id === selectedId) ?? null : null;
@@ -87,24 +100,40 @@ export function PropertyPanel({
               : 'text-slate-400 hover:text-slate-600'
           }`}
         >
-          프레임{frames.length > 0 && ` (${frames.length})`}
+          {oboMode === 'coding_diff'
+            ? `트레이스${traceText.trim() ? ` (${traceText.split('\n').filter(l => l.trim()).length})` : ''}`
+            : `프레임${frames.length > 0 ? ` (${frames.length})` : ''}`}
         </button>
       </div>
 
       {activeTab === 'frame' ? (
         <div className="flex-1 overflow-y-auto">
-          <FramePanel
-            frames={frames}
-            selectedFrameId={selectedFrameId}
-            onSelectFrame={onSelectFrame}
-            onAddFrame={onAddFrame}
-            onRemoveFrame={onRemoveFrame}
-            onUpdateLabel={onUpdateFrameLabel}
-            onRemoveHighlightNode={onRemoveHighlightNode}
-            onRemoveHighlightEdge={onRemoveHighlightEdge}
-            nodes={nodes}
-            edges={edges}
-          />
+          {oboMode === 'coding_diff' ? (
+            <TracePanel
+              nodes={nodes}
+              value={traceText}
+              onChange={onTraceTextChange}
+              testcaseOutputs={testcaseOutputs}
+            />
+          ) : (
+            <FramePanel
+              frames={frames}
+              selectedFrameId={selectedFrameId}
+              onSelectFrame={onSelectFrame}
+              onAddFrame={onAddFrame}
+              onRemoveFrame={onRemoveFrame}
+              onUpdateLabel={onUpdateFrameLabel}
+              onRemoveHighlightNode={onRemoveHighlightNode}
+              onRemoveHighlightEdge={onRemoveHighlightEdge}
+              onAddNodeOverride={onAddNodeOverride}
+              onRemoveNodeOverride={onRemoveNodeOverride}
+              onSetOverrideField={onSetOverrideField}
+              onClearOverrideField={onClearOverrideField}
+              onUpdateFrameCursorTime={onUpdateFrameCursorTime}
+              nodes={nodes}
+              edges={edges}
+            />
+          )}
         </div>
       ) : (
         <>

--- a/components/obo/panel/TracePanel.tsx
+++ b/components/obo/panel/TracePanel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import type { Node } from '@xyflow/react';
+import { exampleStateValue, getStateFields } from '../lib/overrideFields';
+
+interface TracePanelProps {
+  nodes: Node[];
+  value: string;
+  onChange: (text: string) => void;
+  testcaseOutputs?: { index: number; output: string }[];
+}
+
+export function TracePanel({ nodes, value, onChange, testcaseOutputs }: TracePanelProps) {
+  const [pickedIndex, setPickedIndex] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const stepCount = value.split('\n').map(l => l.trim()).filter(Boolean).length;
+
+  const handleImport = () => {
+    if (!pickedIndex) return;
+    const tc = testcaseOutputs?.find(t => String(t.index) === pickedIndex);
+    if (!tc) return;
+    if (value.trim() && !window.confirm('현재 작성된 트레이스를 테스트케이스 출력으로 덮어쓸까요?')) return;
+    onChange(tc.output);
+    setPickedIndex('');
+  };
+
+  // 텍스트박스 커서 위치에 그대로 삽입 — 리렌더로 value가 반영된 다음(requestAnimationFrame)에
+  // 커서 위치를 잡아야 새 텍스트 기준으로 정확한 위치에 놓인다.
+  const insertAtCursor = (text: string) => {
+    const el = textareaRef.current;
+    const start = el?.selectionStart ?? value.length;
+    const end = el?.selectionEnd ?? value.length;
+    onChange(value.slice(0, start) + text + value.slice(end));
+    requestAnimationFrame(() => {
+      el?.focus();
+      const pos = start + text.length;
+      el?.setSelectionRange(pos, pos);
+    });
+  };
+
+  return (
+    <div className="p-3 space-y-3">
+      <p className="text-[10px] text-slate-400 bg-slate-50 rounded px-2 py-1.5 leading-relaxed">
+        코딩 채점 모드는 프레임을 직접 만들지 않습니다. 한 줄 = 한 스텝입니다.
+        <br />줄 안에서 <b>노드 id</b>를 적으면 그 스텝에서 강조되고(연결된 엣지도 자동 강조),
+        노드 id가 아닌 값은 바로 앞 노드 id의 필드값으로 들어갑니다.
+        <br />예: <code>new ready</code> (두 노드 강조) / <code>frames [7,null,null]</code> (frames 노드의 값 지정)
+      </p>
+
+      <div className="space-y-1">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">노드 id 참조</label>
+        {nodes.length === 0 ? (
+          <p className="text-[10px] text-slate-400 italic">캔버스에 노드를 먼저 추가하세요</p>
+        ) : (
+          <div className="grid grid-cols-2 gap-1">
+            {nodes.map(n => {
+              const label = (n.data as { label?: string })?.label ?? n.id;
+              const field = getStateFields(n.type)[0];
+              const example = exampleStateValue(n);
+              return (
+                <button
+                  key={n.id}
+                  type="button"
+                  onClick={() => insertAtCursor(example ? `${n.id} ${example} ` : `${n.id} `)}
+                  title="클릭하면 커서 위치에 삽입됩니다"
+                  className="text-left bg-slate-50 hover:bg-indigo-50 rounded px-1.5 py-1 min-w-0 transition-colors"
+                >
+                  <div className="flex items-baseline gap-1 text-[10px]">
+                    <code className="font-mono font-bold text-indigo-600 shrink-0">{n.id}</code>
+                    <span className="text-slate-500 truncate">{label}</span>
+                    {field && <span className="text-slate-300 shrink-0">· {field}</span>}
+                  </div>
+                  {example && (
+                    <code className="block text-[10px] text-slate-400 truncate">{example}</code>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {testcaseOutputs && testcaseOutputs.length > 0 && (
+        <div className="flex items-center gap-1.5">
+          <select
+            value={pickedIndex}
+            onChange={e => setPickedIndex(e.target.value)}
+            className="flex-1 text-xs border border-slate-200 rounded px-2 py-1 bg-white"
+          >
+            <option value="">테스트케이스 선택...</option>
+            {testcaseOutputs.map(tc => (
+              <option key={tc.index} value={tc.index}>테스트케이스 {tc.index}</option>
+            ))}
+          </select>
+          <button
+            onClick={handleImport}
+            disabled={!pickedIndex}
+            className="shrink-0 px-2 py-1 text-xs rounded border border-indigo-200 text-indigo-600 hover:bg-indigo-50 disabled:opacity-40 disabled:hover:bg-transparent transition-colors"
+          >
+            가져오기
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">정답 트레이스</label>
+          <span className="text-[10px] text-slate-400">{stepCount}스텝 인식됨</span>
+        </div>
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          rows={14}
+          placeholder={'new ready\nready running\nrunning terminated'}
+          className="w-full text-xs font-mono border border-slate-200 rounded px-2 py-1.5 outline-none focus:border-indigo-400 transition-colors resize-y"
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/obo/panel/fields/ListEditor.tsx
+++ b/components/obo/panel/fields/ListEditor.tsx
@@ -1,15 +1,11 @@
 'use client';
 
-export interface SlotCell {
-  value?: string;
-  status?: 'default' | 'fault' | 'hit' | 'empty';
-}
+import { TIMELINE_COLOR_KEYS, DEFAULT_TIMELINE_COLOR_KEY } from '../../nodes/ganttColors';
 
 export interface GanttBlock {
-  label: string;
   start: number;
   end: number;
-  color?: string;
+  colorKey: string;
 }
 
 export interface ChartSeries {
@@ -19,7 +15,6 @@ export interface ChartSeries {
 }
 
 type ListEditorProps =
-  | { mode: 'cells';  value: SlotCell[];    onChange: (v: SlotCell[]) => void }
   | { mode: 'blocks'; value: GanttBlock[];  onChange: (v: GanttBlock[]) => void }
   | { mode: 'series'; value: ChartSeries[]; onChange: (v: ChartSeries[]) => void };
 
@@ -28,41 +23,6 @@ const addBtnCls = 'w-full text-xs text-indigo-500 hover:text-indigo-700 py-1 bor
 const delBtnCls = 'shrink-0 text-slate-300 hover:text-red-400 text-xs px-1 leading-none transition-colors';
 
 export function ListEditor(props: ListEditorProps) {
-  if (props.mode === 'cells') {
-    const { value: cells, onChange } = props;
-    const update = (i: number, patch: Partial<SlotCell>) =>
-      onChange(cells.map((c, j) => j === i ? { ...c, ...patch } : c));
-
-    return (
-      <div className="space-y-1.5">
-        {cells.map((cell, i) => (
-          <div key={i} className="flex items-center gap-1.5">
-            <input
-              value={cell.value ?? ''}
-              onChange={e => update(i, { value: e.target.value })}
-              placeholder="값"
-              className={`w-14 ${inputCls}`}
-            />
-            <select
-              value={cell.status ?? 'default'}
-              onChange={e => update(i, { status: e.target.value as SlotCell['status'] })}
-              className="flex-1 px-1 py-1 text-xs border border-slate-200 rounded bg-white"
-            >
-              <option value="default">기본</option>
-              <option value="fault">결함</option>
-              <option value="hit">히트</option>
-              <option value="empty">빈칸</option>
-            </select>
-            <button onClick={() => onChange(cells.filter((_, j) => j !== i))} className={delBtnCls}>✕</button>
-          </div>
-        ))}
-        <button onClick={() => onChange([...cells, { value: '', status: 'default' }])} className={addBtnCls}>
-          + 셀 추가
-        </button>
-      </div>
-    );
-  }
-
   if (props.mode === 'blocks') {
     const { value: blocks, onChange } = props;
     const update = (i: number, patch: Partial<GanttBlock>) =>
@@ -73,13 +33,7 @@ export function ListEditor(props: ListEditorProps) {
         {blocks.map((block, i) => (
           <div key={i} className="relative border border-slate-100 rounded-lg p-2 space-y-1.5">
             <button onClick={() => onChange(blocks.filter((_, j) => j !== i))} className="absolute top-1.5 right-1.5 text-slate-300 hover:text-red-400 text-xs transition-colors">✕</button>
-            <input
-              value={block.label}
-              onChange={e => update(i, { label: e.target.value })}
-              placeholder="라벨"
-              className={`w-full pr-5 ${inputCls}`}
-            />
-            <div className="flex items-end gap-1.5">
+            <div className="flex items-end gap-1.5 pr-5">
               <div className="flex-1">
                 <p className="text-[9px] text-slate-400 mb-0.5">시작</p>
                 <input type="number" min={0} value={block.start}
@@ -92,18 +46,22 @@ export function ListEditor(props: ListEditorProps) {
                   onChange={e => update(i, { end: Number(e.target.value) })}
                   className={`w-full ${inputCls}`} />
               </div>
-              <div>
-                <p className="text-[9px] text-slate-400 mb-0.5">색</p>
-                <div className="relative w-8 h-[26px] rounded border border-slate-200" style={{ backgroundColor: block.color ?? '#1D9E75' }}>
-                  <input type="color" value={block.color ?? '#1D9E75'}
-                    onChange={e => update(i, { color: e.target.value })}
-                    className="absolute inset-0 opacity-0 w-full h-full cursor-pointer" />
-                </div>
+              <div className="flex-1">
+                <p className="text-[9px] text-slate-400 mb-0.5">색상 키</p>
+                <select
+                  value={block.colorKey ?? DEFAULT_TIMELINE_COLOR_KEY}
+                  onChange={e => update(i, { colorKey: e.target.value })}
+                  className="w-full px-1 py-1 text-xs border border-slate-200 rounded bg-white"
+                >
+                  {TIMELINE_COLOR_KEYS.map(k => (
+                    <option key={k} value={k}>{k}</option>
+                  ))}
+                </select>
               </div>
             </div>
           </div>
         ))}
-        <button onClick={() => onChange([...blocks, { label: 'P', start: 0, end: 2, color: '#1D9E75' }])} className={addBtnCls}>
+        <button onClick={() => onChange([...blocks, { start: 0, end: 2, colorKey: DEFAULT_TIMELINE_COLOR_KEY }])} className={addBtnCls}>
           + 블록 추가
         </button>
       </div>

--- a/components/obo/panel/overrides/CounterBadgeOverrideForm.tsx
+++ b/components/obo/panel/overrides/CounterBadgeOverrideForm.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { OverrideFormProps } from './NodeOverrideEditor';
+
+export function CounterBadgeOverrideForm({ node, base, override, onFieldChange, onFieldClear }: OverrideFormProps) {
+  const min = (node.data as { min?: number }).min ?? 0;
+  const max = (node.data as { max?: number }).max ?? 10;
+  const value = (override.value as number | undefined) ?? (base.value as number | undefined) ?? min;
+  const delta = (override.delta as number | null | undefined) ?? null;
+
+  const clamp = (v: number) => Math.min(max, Math.max(min, v));
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">값</label>
+        <input
+          type="number" min={min} max={max} value={value}
+          onChange={e => { const v = Number(e.target.value); if (!isNaN(v)) onFieldChange('value', clamp(v)); }}
+          className="w-full text-xs border border-slate-200 rounded px-2 py-1 outline-none focus:border-indigo-400 transition-colors"
+        />
+      </div>
+      <div className="space-y-1">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">변화량 (이번 프레임)</label>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={() => onFieldChange('delta', 1)}
+            className={`px-2 py-1 text-xs rounded border transition-colors ${delta === 1 ? 'bg-emerald-50 border-emerald-300 text-emerald-700' : 'border-slate-200 text-slate-500 hover:bg-slate-50'}`}
+          >+1</button>
+          <button
+            onClick={() => onFieldChange('delta', -1)}
+            className={`px-2 py-1 text-xs rounded border transition-colors ${delta === -1 ? 'bg-red-50 border-red-300 text-red-700' : 'border-slate-200 text-slate-500 hover:bg-slate-50'}`}
+          >-1</button>
+          <button
+            onClick={() => onFieldClear('delta')}
+            className="px-2 py-1 text-xs rounded border border-slate-200 text-slate-400 hover:bg-slate-50 transition-colors"
+          >지우기</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/obo/panel/overrides/NodeOverrideEditor.tsx
+++ b/components/obo/panel/overrides/NodeOverrideEditor.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { Node } from '@xyflow/react';
+import type { Frame } from '../../types';
+import { applyFrame } from '../../lib/applyFrame';
+import { TextLabelOverrideForm } from './TextLabelOverrideForm';
+import { TimelineBlockOverrideForm } from './TimelineBlockOverrideForm';
+import { SlotGridOverrideForm } from './SlotGridOverrideForm';
+import { CounterBadgeOverrideForm } from './CounterBadgeOverrideForm';
+
+export interface OverrideFormProps {
+  node: Node;
+  base: Record<string, unknown>;
+  override: Record<string, unknown>;
+  onFieldChange: (field: string, value: unknown) => void;
+  onFieldClear: (field: string) => void;
+}
+
+interface NodeOverrideEditorProps {
+  node: Node;
+  frames: Frame[];
+  frameIndex: number;
+  override: Record<string, unknown>;
+  onFieldChange: (field: string, value: unknown) => void;
+  onFieldClear: (field: string) => void;
+}
+
+export function NodeOverrideEditor({ node, frames, frameIndex, override, onFieldChange, onFieldClear }: NodeOverrideEditorProps) {
+  // 이 프레임의 override가 적용되기 "전" 캐리포워드 값 — 폼이 편집 기준으로 삼는 baseline
+  const base = (applyFrame([node], frames, frameIndex - 1)[0].data ?? {}) as Record<string, unknown>;
+  const formProps: OverrideFormProps = { node, base, override, onFieldChange, onFieldClear };
+
+  switch (node.type) {
+    case 'text-label':
+      return <TextLabelOverrideForm {...formProps} />;
+    case 'gantt-lane':
+      return <TimelineBlockOverrideForm {...formProps} />;
+    case 'slot-grid':
+      return <SlotGridOverrideForm {...formProps} />;
+    case 'counter-badge':
+      return <CounterBadgeOverrideForm {...formProps} />;
+    default:
+      return <p className="text-[10px] text-slate-400">오버라이드할 수 없는 노드 타입입니다.</p>;
+  }
+}

--- a/components/obo/panel/overrides/SlotGridOverrideForm.tsx
+++ b/components/obo/panel/overrides/SlotGridOverrideForm.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import type { OverrideFormProps } from './NodeOverrideEditor';
+
+export function SlotGridOverrideForm({ node, base, override, onFieldChange, onFieldClear }: OverrideFormProps) {
+  const slotCount = (node.data as { slotCount?: number }).slotCount ?? 0;
+  const slots = (override.slots as (number | null)[] | undefined) ?? (base.slots as (number | null)[] | undefined) ?? [];
+  const faultSlotIndex = (override.faultSlotIndex as number | null | undefined) ?? null;
+  const hitSlotIndex = (override.hitSlotIndex as number | null | undefined) ?? null;
+
+  const updateSlot = (i: number, raw: string) => {
+    const next = Array.from({ length: slotCount }, (_, j) => slots[j] ?? null);
+    next[i] = raw === '' ? null : Number(raw);
+    onFieldChange('slots', next);
+  };
+
+  const eventSelect = (
+    label: string,
+    field: 'faultSlotIndex' | 'hitSlotIndex',
+    value: number | null,
+  ) => (
+    <div className="space-y-1">
+      <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">{label}</label>
+      <select
+        value={value ?? ''}
+        onChange={e => e.target.value === '' ? onFieldClear(field) : onFieldChange(field, Number(e.target.value))}
+        className="w-full px-1.5 py-1 text-xs border border-slate-200 rounded bg-white"
+      >
+        <option value="">없음</option>
+        {Array.from({ length: slotCount }).map((_, i) => <option key={i} value={i}>슬롯 {i}</option>)}
+      </select>
+    </div>
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">슬롯 값</label>
+        <div className="flex flex-wrap gap-1.5">
+          {Array.from({ length: slotCount }).map((_, i) => (
+            <input
+              key={i}
+              value={slots[i] ?? ''}
+              onChange={e => updateSlot(i, e.target.value)}
+              placeholder="-"
+              className="w-10 px-1 py-1 text-xs text-center border border-slate-200 rounded bg-white focus:outline-none focus:ring-1 focus:ring-indigo-300"
+            />
+          ))}
+        </div>
+      </div>
+      {eventSelect('폴트 슬롯 (이번 프레임)', 'faultSlotIndex', faultSlotIndex)}
+      {eventSelect('히트 슬롯 (이번 프레임)', 'hitSlotIndex', hitSlotIndex)}
+    </div>
+  );
+}

--- a/components/obo/panel/overrides/TextLabelOverrideForm.tsx
+++ b/components/obo/panel/overrides/TextLabelOverrideForm.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import type { OverrideFormProps } from './NodeOverrideEditor';
+
+export function TextLabelOverrideForm({ base, override, onFieldChange }: OverrideFormProps) {
+  const value = (override.text as string | undefined) ?? (base.text as string | undefined) ?? '';
+
+  return (
+    <div className="space-y-1">
+      <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">텍스트</label>
+      <input
+        value={value}
+        onChange={e => onFieldChange('text', e.target.value)}
+        className="w-full text-xs border border-slate-200 rounded px-2 py-1 outline-none focus:border-indigo-400 transition-colors"
+      />
+    </div>
+  );
+}

--- a/components/obo/panel/overrides/TimelineBlockOverrideForm.tsx
+++ b/components/obo/panel/overrides/TimelineBlockOverrideForm.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { OverrideFormProps } from './NodeOverrideEditor';
+import { TIMELINE_COLOR_KEYS, DEFAULT_TIMELINE_COLOR_KEY } from '../../nodes/ganttColors';
+
+interface TimelineBlock {
+  start: number;
+  end: number;
+  colorKey: string;
+}
+
+export function TimelineBlockOverrideForm({ base, override, onFieldChange, onFieldClear }: OverrideFormProps) {
+  const blocks = (override.blocks as TimelineBlock[] | undefined) ?? (base.blocks as TimelineBlock[] | undefined) ?? [];
+  const activeBlockIndex = (override.activeBlockIndex as number | null | undefined) ?? null;
+
+  const updateBlocks = (next: TimelineBlock[]) => onFieldChange('blocks', next);
+  const updateBlock = (i: number, patch: Partial<TimelineBlock>) =>
+    updateBlocks(blocks.map((b, j) => j === i ? { ...b, ...patch } : b));
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">블록 목록</label>
+        {blocks.map((b, i) => (
+          <div key={i} className="relative border border-slate-100 rounded-lg p-2 flex items-end gap-1.5">
+            <button
+              onClick={() => updateBlocks(blocks.filter((_, j) => j !== i))}
+              className="absolute top-1.5 right-1.5 text-slate-300 hover:text-red-400 text-xs transition-colors"
+            >✕</button>
+            <div className="flex-1">
+              <p className="text-[9px] text-slate-400 mb-0.5">시작</p>
+              <input type="number" min={0} value={b.start}
+                onChange={e => updateBlock(i, { start: Number(e.target.value) })}
+                className="w-full px-1.5 py-1 text-xs border border-slate-200 rounded" />
+            </div>
+            <div className="flex-1">
+              <p className="text-[9px] text-slate-400 mb-0.5">종료</p>
+              <input type="number" min={0} value={b.end}
+                onChange={e => updateBlock(i, { end: Number(e.target.value) })}
+                className="w-full px-1.5 py-1 text-xs border border-slate-200 rounded" />
+            </div>
+            <div className="flex-1 pr-4">
+              <p className="text-[9px] text-slate-400 mb-0.5">색상 키</p>
+              <select value={b.colorKey ?? DEFAULT_TIMELINE_COLOR_KEY}
+                onChange={e => updateBlock(i, { colorKey: e.target.value })}
+                className="w-full px-1 py-1 text-xs border border-slate-200 rounded bg-white">
+                {TIMELINE_COLOR_KEYS.map(k => <option key={k} value={k}>{k}</option>)}
+              </select>
+            </div>
+          </div>
+        ))}
+        <button
+          onClick={() => updateBlocks([...blocks, { start: 0, end: 2, colorKey: DEFAULT_TIMELINE_COLOR_KEY }])}
+          className="w-full text-xs text-indigo-500 hover:text-indigo-700 py-1 border border-dashed border-indigo-200 rounded transition-colors"
+        >+ 블록 추가</button>
+      </div>
+
+      <div className="space-y-1">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wide">활성 블록 (이번 프레임)</label>
+        <select
+          value={activeBlockIndex ?? ''}
+          onChange={e => e.target.value === '' ? onFieldClear('activeBlockIndex') : onFieldChange('activeBlockIndex', Number(e.target.value))}
+          className="w-full px-1.5 py-1 text-xs border border-slate-200 rounded bg-white"
+        >
+          <option value="">없음</option>
+          {blocks.map((_, i) => <option key={i} value={i}>블록 {i}</option>)}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/components/obo/templates.ts
+++ b/components/obo/templates.ts
@@ -1,10 +1,12 @@
 import type { Node, Edge } from '@xyflow/react';
+import type { Frame } from './types';
 
 // ── 팔레트 원소 타입 ───────────────────────────────────────────────
 export type NodeComponentType =
   | 'state-node'
   | 'resource-square'
-  | 'slot-grid';
+  | 'slot-grid'
+  | 'counter-badge';
 
 export type ChartComponentType =
   | 'gantt-lane'
@@ -33,9 +35,12 @@ export interface PaletteItem {
 }
 
 export const PALETTE_ITEMS: PaletteItem[] = [
-  { type: 'state-node', group: 'node', label: 'State Node', description: '상태/엔터티 (ST2)' },
-  { type: 'text-label', group: 'text', label: 'Text Label', description: '텍스트/주석' },
-  // 비활성: resource-square, slot-grid, gantt-lane, line-chart
+  { type: 'state-node',    group: 'node',  label: 'State Node',      description: '상태/엔터티 (ST2)' },
+  { type: 'text-label',    group: 'text',  label: 'Text Label',      description: '텍스트/주석' },
+  { type: 'slot-grid',     group: 'node',  label: 'Slot Grid',       description: '페이지/슬롯 배열 (FIFO/LRU/Belady)' },
+  { type: 'gantt-lane',    group: 'node',  label: 'Timeline Block',  description: '스케줄링 간트 차트 트랙' },
+  { type: 'counter-badge', group: 'node',  label: 'Counter Badge',   description: '세마포어/버퍼 카운트' },
+  // 비활성: resource-square, line-chart
 ];
 
 export const PALETTE_GROUPS = [
@@ -58,6 +63,7 @@ export interface OBOTemplate {
   description: string;
   defaultNodes: Node[];
   defaultEdges: Edge[];
+  defaultFrames?: Frame[];
 }
 
 export const OBO_TEMPLATES: OBOTemplate[] = [
@@ -104,7 +110,7 @@ export const OBO_TEMPLATES: OBOTemplate[] = [
         source: 'new',       sourceHandle: 'r',
         target: 'ready',     targetHandle: 'l',
         type: 'obo-edge',
-        data: { label: 'admitted', direction: 'forward', style: 'solid', role: 'transition', highlight: false },
+        data: { label: 'admitted', direction: 'forward', style: 'solid', role: 'transition', emphasize: false },
       },
       {
         // dispatch: Ready 하단 → Running 좌측 (아래-오른쪽 곡선)
@@ -112,7 +118,7 @@ export const OBO_TEMPLATES: OBOTemplate[] = [
         source: 'ready',   sourceHandle: 'b',
         target: 'running', targetHandle: 'l',
         type: 'obo-edge',
-        data: { label: 'dispatch', direction: 'forward', style: 'solid', role: 'transition', highlight: false },
+        data: { label: 'dispatch', direction: 'forward', style: 'solid', role: 'transition', emphasize: false },
       },
       {
         // interrupt: Running 상단 → Ready 우측 (위-왼쪽 곡선)
@@ -120,28 +126,237 @@ export const OBO_TEMPLATES: OBOTemplate[] = [
         source: 'running', sourceHandle: 't',
         target: 'ready',   targetHandle: 'r',
         type: 'obo-edge',
-        data: { label: 'interrupt', direction: 'forward', style: 'solid', role: 'transition', highlight: false },
+        data: { label: 'interrupt', direction: 'forward', style: 'solid', role: 'transition', emphasize: false },
       },
       {
         id: 'e-running-waiting',
         source: 'running', sourceHandle: 'b',
         target: 'waiting', targetHandle: 'r',
         type: 'obo-edge',
-        data: { label: 'I/O wait', direction: 'forward', style: 'solid', role: 'transition', highlight: false },
+        data: { label: 'I/O wait', direction: 'forward', style: 'solid', role: 'transition', emphasize: false },
       },
       {
         id: 'e-waiting-ready',
         source: 'waiting', sourceHandle: 't',
         target: 'ready',   targetHandle: 'b',
         type: 'obo-edge',
-        data: { label: 'I/O done', direction: 'forward', style: 'solid', role: 'transition', highlight: false },
+        data: { label: 'I/O done', direction: 'forward', style: 'solid', role: 'transition', emphasize: false },
       },
       {
         id: 'e-running-terminated',
         source: 'running',    sourceHandle: 'r',
         target: 'terminated', targetHandle: 'l',
         type: 'obo-edge',
-        data: { label: 'exit', direction: 'forward', style: 'solid', role: 'transition', highlight: false },
+        data: { label: 'exit', direction: 'forward', style: 'solid', role: 'transition', emphasize: false },
+      },
+    ],
+  },
+  {
+    id: 'S1',
+    name: '페이지 교체 (FIFO)',
+    category: 'memory',
+    description: 'Slot Grid',
+    defaultNodes: [
+      {
+        id: 'ref-string',
+        type: 'text-label',
+        position: { x: 40, y: 30 },
+        data: { text: '참조열: 7 0 1 2 0 3 0 4  (프레임 3개, FIFO)', variant: 'plain', color: '#334155' },
+      },
+      {
+        id: 'status',
+        type: 'text-label',
+        position: { x: 40, y: 62 },
+        data: { text: '프레임 탭에서 재생해 보세요 →', variant: 'pill', color: '#6366f1' },
+      },
+      {
+        id: 'frames',
+        type: 'slot-grid',
+        position: { x: 40, y: 110 },
+        data: { slotCount: 3, slots: [null, null, null], faultSlotIndex: null, hitSlotIndex: null },
+      },
+    ],
+    defaultEdges: [],
+    defaultFrames: [
+      {
+        id: 'f_1', label: '참조 7 (fault)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [7, null, null], faultSlotIndex: 0 },
+          status: { text: '참조 7 → FAULT · slot 0에 적재' },
+        },
+      },
+      {
+        id: 'f_2', label: '참조 0 (fault)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [7, 0, null], faultSlotIndex: 1 },
+          status: { text: '참조 0 → FAULT · slot 1에 적재' },
+        },
+      },
+      {
+        id: 'f_3', label: '참조 1 (fault)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [7, 0, 1], faultSlotIndex: 2 },
+          status: { text: '참조 1 → FAULT · slot 2에 적재 (프레임 가득 참)' },
+        },
+      },
+      {
+        id: 'f_4', label: '참조 2 (fault, 교체)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [2, 0, 1], faultSlotIndex: 0 },
+          status: { text: '참조 2 → FAULT · 가장 먼저 들어온 slot 0(7) 교체' },
+        },
+      },
+      {
+        id: 'f_5', label: '참조 0 (hit)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { hitSlotIndex: 1 },
+          status: { text: '참조 0 → HIT · slot 1' },
+        },
+      },
+      {
+        id: 'f_6', label: '참조 3 (fault, 교체)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [2, 3, 1], faultSlotIndex: 1 },
+          status: { text: '참조 3 → FAULT · 가장 먼저 들어온 slot 1(0) 교체' },
+        },
+      },
+      {
+        id: 'f_7', label: '참조 0 (fault, 교체)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [2, 3, 0], faultSlotIndex: 2 },
+          status: { text: '참조 0 → FAULT · 가장 먼저 들어온 slot 2(1) 교체' },
+        },
+      },
+      {
+        id: 'f_8', label: '참조 4 (fault, 교체)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          frames: { slots: [4, 3, 0], faultSlotIndex: 0 },
+          status: { text: '참조 4 → FAULT · 가장 먼저 들어온 slot 0(2) 교체 · 총 7 fault / 1 hit' },
+        },
+      },
+    ],
+  },
+  {
+    id: 'G1',
+    name: 'CPU 스케줄링 (FCFS)',
+    category: 'cpu',
+    description: 'Timeline Block',
+    defaultNodes: [
+      {
+        id: 'schedule-title',
+        type: 'text-label',
+        position: { x: 40, y: 20 },
+        data: { text: 'FCFS 스케줄링 · P1(3) → P2(3) → P3(3)', variant: 'plain', color: '#334155' },
+      },
+      {
+        id: 'status',
+        type: 'text-label',
+        position: { x: 40, y: 52 },
+        data: { text: '프레임 탭에서 재생해 보세요 →', variant: 'pill', color: '#6366f1' },
+      },
+      {
+        id: 'track-p1',
+        type: 'gantt-lane',
+        position: { x: 40, y: 100 },
+        data: { trackId: 'P1', blocks: [], activeBlockIndex: null },
+      },
+      {
+        id: 'track-p2',
+        type: 'gantt-lane',
+        position: { x: 40, y: 160 },
+        data: { trackId: 'P2', blocks: [], activeBlockIndex: null },
+      },
+      {
+        id: 'track-p3',
+        type: 'gantt-lane',
+        position: { x: 40, y: 220 },
+        data: { trackId: 'P3', blocks: [], activeBlockIndex: null },
+      },
+    ],
+    defaultEdges: [],
+    defaultFrames: [
+      {
+        id: 'f_1', label: 'P1 디스패치 (0~3)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          'track-p1': { blocks: [{ start: 0, end: 3, colorKey: 'teal' }], activeBlockIndex: 0 },
+          status: { text: 'P1 디스패치 (0~3)' },
+        },
+      },
+      {
+        id: 'f_2', label: 'P2 디스패치 (3~6)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          'track-p2': { blocks: [{ start: 3, end: 6, colorKey: 'indigo' }], activeBlockIndex: 0 },
+          status: { text: 'P1 종료 → P2 디스패치 (3~6)' },
+        },
+      },
+      {
+        id: 'f_3', label: 'P3 디스패치 (6~9)', highlightNodes: [], highlightEdges: [],
+        nodeDataOverrides: {
+          'track-p3': { blocks: [{ start: 6, end: 9, colorKey: 'amber' }], activeBlockIndex: 0 },
+          status: { text: 'P2 종료 → P3 디스패치 (6~9) · 모든 프로세스 완료' },
+        },
+      },
+    ],
+  },
+  {
+    id: 'C1',
+    name: '세마포어 (생산자-소비자)',
+    category: 'sync',
+    description: 'Counter Badge',
+    defaultNodes: [
+      {
+        id: 'producer',
+        type: 'state-node',
+        position: { x: 40, y: 140 },
+        data: { label: 'Producer', shape: 'box', fill: '#0d9488' },
+      },
+      {
+        id: 'empty-badge',
+        type: 'counter-badge',
+        position: { x: 280, y: 80 },
+        data: { label: 'empty', min: 0, max: 3, value: 3, delta: null },
+      },
+      {
+        id: 'full-badge',
+        type: 'counter-badge',
+        position: { x: 280, y: 200 },
+        data: { label: 'full', min: 0, max: 3, value: 0, delta: null },
+      },
+      {
+        id: 'consumer',
+        type: 'state-node',
+        position: { x: 520, y: 140 },
+        data: { label: 'Consumer', shape: 'box', fill: '#7c3aed' },
+      },
+    ],
+    defaultEdges: [
+      {
+        id: 'e-producer-empty',
+        source: 'producer', sourceHandle: 'r',
+        target: 'empty-badge', targetHandle: 'l',
+        type: 'obo-edge',
+        data: { label: 'wait(empty)', direction: 'forward', style: 'dashed', role: 'request', emphasize: false },
+      },
+      {
+        id: 'e-producer-full',
+        source: 'producer', sourceHandle: 'r',
+        target: 'full-badge', targetHandle: 'l',
+        type: 'obo-edge',
+        data: { label: 'signal(full)', direction: 'forward', style: 'solid', role: 'allocation', emphasize: false },
+      },
+      {
+        id: 'e-consumer-full',
+        source: 'consumer', sourceHandle: 'l',
+        target: 'full-badge', targetHandle: 'r',
+        type: 'obo-edge',
+        data: { label: 'wait(full)', direction: 'forward', style: 'dashed', role: 'request', emphasize: false },
+      },
+      {
+        id: 'e-consumer-empty',
+        source: 'consumer', sourceHandle: 'l',
+        target: 'empty-badge', targetHandle: 'r',
+        type: 'obo-edge',
+        data: { label: 'signal(empty)', direction: 'forward', style: 'solid', role: 'allocation', emphasize: false },
       },
     ],
   },
@@ -149,6 +364,8 @@ export const OBO_TEMPLATES: OBOTemplate[] = [
 ];
 
 export const CATEGORIES = [
-  { id: 'all', label: '전체', count: 1 },
-  { id: 'cpu', label: 'CPU',  count: 1 },
+  { id: 'all',    label: '전체',   count: 4 },
+  { id: 'cpu',    label: 'CPU',    count: 2 },
+  { id: 'memory', label: 'Memory', count: 1 },
+  { id: 'sync',   label: 'Sync',   count: 1 },
 ] as const;

--- a/components/obo/types.ts
+++ b/components/obo/types.ts
@@ -1,16 +1,35 @@
+import { generateFramesFromTrace } from './lib/trace';
+
 export interface Frame {
   id: string;
   label: string;
   highlightNodes: string[];
   highlightEdges: string[];
+  nodeDataOverrides?: Record<string, Record<string, unknown>>;
+  cursorTime?: number;
 }
 
-export type OboMode = 'single' | 'per_choice';
+export type OboMode = 'single' | 'per_choice' | 'coding_diff';
+
+// 트레이스 한 스텝. overrides는 그 시점의 nodeDataOverrides(Frame.nodeDataOverrides와 같은 모양,
+// carry-forward 대상)이고, highlightNodes는 그 스텝에서 강조되는 노드 id들(carry-forward 없음).
+// 채점 대상(어떤 노드/필드를 비교할지)은 별도로 저장하지 않고 트레이스에 실제로 등장하는 값/강조에서 자동 도출한다.
+export interface OboTraceStep {
+  overrides: Record<string, Record<string, unknown>>;
+  highlightNodes: string[];
+}
+
+export interface OboCodingSchema {
+  nodes: OboBlob['nodes'];
+  edges: OboBlob['edges'];
+  referenceTrace: OboTraceStep[]; // 정답 코드 실행 트레이스 — 프레임/채점 대상 전부 이걸로부터 자동 파생됨
+}
 
 export interface ProblemOboData {
   mode: OboMode;
   single?: OboBlob;
   perChoice?: Record<string, OboBlob>;
+  codingDiff?: OboCodingSchema;
 }
 
 export interface OboBlob {
@@ -45,6 +64,12 @@ export function resolveOboBlob(
 
   if (normalized.mode === 'single') {
     return normalized.single ?? null;
+  }
+
+  if (normalized.mode === 'coding_diff') {
+    const schema = normalized.codingDiff;
+    if (!schema) return null;
+    return { nodes: schema.nodes, edges: schema.edges, frames: generateFramesFromTrace(schema.referenceTrace, schema.edges) };
   }
 
   if (selectedChoiceIndex == null) return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "eslint-config-next": "16.2.2",
         "playwright": "^1.58.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -666,21 +667,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -688,9 +689,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1921,6 +1922,16 @@
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3466,6 +3477,307 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4435,14 +4747,25 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -4541,6 +4864,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -5207,6 +5537,119 @@
         "react": ">= 16.8.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.1",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.1.tgz",
@@ -5565,6 +6008,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -5829,6 +6282,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6837,6 +7300,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7343,6 +7813,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7413,6 +7893,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -9819,9 +10309,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -10170,6 +10660,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -10430,6 +10934,13 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10500,9 +11011,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10519,7 +11030,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11267,6 +11778,40 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/rope-sequence": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -11763,6 +12308,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -11834,6 +12386,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -11848,6 +12407,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -12181,10 +12747,27 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12227,6 +12810,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldraw": {
@@ -12765,6 +13358,215 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -12882,6 +13684,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
@@ -41,6 +42,7 @@
     "eslint-config-next": "16.2.2",
     "playwright": "^1.58.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.10"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});


### PR DESCRIPTION
- coding_diff 모드 도입: 정답 트레이스를 자유 텍스트로 입력하면 parseTraceText가 노드 강조/필드값을 스텝 단위로 파싱하고, generateFramesFromTrace가 이를 프레임으로 자동 변환
- 제출 트레이스를 정답 트레이스와 비교해 체크포인트별 정답/오답을 판정하고, 첫 오답 지점까지만 재생되도록 OboPlayer에 maxFrameIndex/checkpointStatusByFrame/autoPlay 옵션 추가
- CodingDiffPlayer, TracePanel, CheckpointStatusRing, NodeOverrideEditor 및 노드별 override 폼(CounterBadge/SlotGrid/ TextLabel/TimelineBlock) 신규 추가
- CounterBadgeNode 노드 타입 추가, GanttLane/SlotGrid/StateNode/ TextLabel 등 기존 노드가 오버라이드 값을 반영하도록 리팩터링
- 문제 생성 페이지(challenges/create)에서 coding 타입일 때 테스트케이스 출력을 트레이스로 가져올 수 있도록 연동
- vitest 테스트 러너 도입 (trace/applyFrame/codingDiff/overrideFields 단위 테스트 추가), package.json에 test 스크립트 추가